### PR TITLE
🧑‍🔬 Prototype: Enforcing MFA for owners of top 100 downloaded gems (CLI)

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -25,6 +25,11 @@ class Api::BaseController < ApplicationController
     end
   end
 
+  def check_user_mfa_requirement
+    return unless @api_key.user&.mfa_required?
+    render plain: t(:user_mfa_required), status: :forbidden
+  end
+
   def verify_with_otp
     otp = request.headers["HTTP_OTP"]
     return if @api_key.user.mfa_api_authorized?(otp)

--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -47,7 +47,9 @@ class Api::V1::ApiKeysController < Api::BaseController
   private
 
   def check_mfa(user)
-    if user&.mfa_gem_signin_authorized?(otp)
+    if user&.mfa_required?
+      render plain: t(:user_mfa_required), status: :forbidden
+    elsif user&.mfa_gem_signin_authorized?(otp)
       yield
     elsif user&.mfa_enabled?
       prompt_text = otp.present? ? t(:otp_incorrect) : t(:otp_missing)

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::DeletionsController < Api::BaseController
   before_action :verify_with_otp
   before_action :render_api_key_forbidden, if: :api_key_unauthorized?
   before_action :verify_mfa_requirement
+  before_action :check_user_mfa_requirement
 
   def create
     @deletion = @api_key.user.deletions.build(version: @version)

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -4,6 +4,7 @@ class Api::V1::OwnersController < Api::BaseController
   before_action :verify_gem_ownership, except: %i[show gems]
   before_action :verify_mfa_requirement, except: %i[show gems]
   before_action :verify_with_otp, except: %i[show gems]
+  before_action :check_user_mfa_requirement, except: %i[show gems]
 
   def show
     respond_to do |format|

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -3,6 +3,7 @@ class Api::V1::RubygemsController < Api::BaseController
   before_action :find_rubygem,              only: %i[show reverse_dependencies]
   before_action :cors_preflight_check, only: :show
   before_action :verify_with_otp, only: %i[create]
+  before_action :check_user_mfa_requirement, only: %i[create]
   after_action  :cors_set_access_control_headers, only: :show
 
   def index

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
   none: None
   not_found: Not Found
   api_key_forbidden: The API key doesn't have access
+  user_mfa_required: For protection of your account and your gems, please setup multi-factor authentication at https://rubygems.org/multifactor_auth/new
   please_sign_up: Access Denied. Please sign up for an account at https://rubygems.org
   please_sign_in: Please sign in to continue.
   otp_incorrect: Your OTP code is incorrect. Please check it and retry.


### PR DESCRIPTION
### Description
Builds off of https://github.com/Shopify/rubygems.org/pull/2, but could be easily ported to the most up to date UI prototype https://github.com/Shopify/rubygems.org/pull/8.

 When a user tries to signin, push/yank gems, and add/remove owners, a message renders to make the user setup MFA if the user doesn't have MFA enabled with the forbidden response. This is only limited to the accounts that is targeted by `mfa_required?`.

### Gem signin
<img width="1033" alt="Screen Shot 2022-01-11 at 9 15 12 PM" src="https://user-images.githubusercontent.com/42748004/149051974-c41b9d86-2a16-4b68-a285-217c15672bc6.png">

### Gem push
<img width="1114" alt="Screen Shot 2022-01-11 at 9 16 41 PM" src="https://user-images.githubusercontent.com/42748004/149051968-8ab38617-fc62-4ff1-8d85-82c6c6a51e42.png">

