### PR TITLE
🧑‍🔬 Prototype: Enforcing MFA for owners of top 100 downloaded gems (UI)(Option 1️⃣)

### DIFF
--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -1,6 +1,7 @@
 class ApiKeysController < ApplicationController
   include ApiKeyable
   before_action :redirect_to_signin, unless: :signed_in?
+  before_action :redirect_to_mfa, if: :mfa_required?
   before_action :redirect_to_verify, unless: :password_session_active?
 
   def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,6 +49,14 @@ class ApplicationController < ActionController::Base
     redirect_to sign_in_path, alert: t("please_sign_in")
   end
 
+  def mfa_required?
+    current_user&.mfa_required?
+  end
+
+  def redirect_to_mfa
+    redirect_to new_multifactor_auth_path if current_user&.mfa_required?
+  end
+
   def find_rubygem
     @rubygem = Rubygem.find_by_name(params[:rubygem_id] || params[:id])
     return if @rubygem

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,7 +54,7 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_to_mfa
-    redirect_to new_multifactor_auth_path if current_user&.mfa_required?
+    redirect_to new_multifactor_auth_path
   end
 
   def find_rubygem

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,5 +1,6 @@
 class DashboardsController < ApplicationController
   before_action :authenticate_with_api_key, unless: :signed_in?
+  before_action :redirect_to_mfa, if: :mfa_required?
   before_action :redirect_to_signin, unless: -> { signed_in? || @api_key&.can_show_dashboard? }
 
   def show

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -1,5 +1,7 @@
 class EmailConfirmationsController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?, only: :unconfirmed
+  # TODO: THINK ABOUT THE UNCONFIRMED FLOW
+  before_action :redirect_to_mfa, if: :mfa_required?
   before_action :validate_confirmation_token, only: %i[update mfa_update]
 
   def update

--- a/app/controllers/notifiers_controller.rb
+++ b/app/controllers/notifiers_controller.rb
@@ -1,5 +1,6 @@
 class NotifiersController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?
+  before_action :redirect_to_mfa, if: :mfa_required?
 
   def show
     @ownerships = current_user.ownerships.by_indexed_gem_name

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?, except: :show
+  before_action :redirect_to_mfa, if: :mfa_required?, except: :show
   before_action :verify_password, only: %i[update destroy]
   before_action :set_cache_headers, only: :edit
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,7 @@
 class SessionsController < Clearance::SessionsController
   before_action :redirect_to_signin, unless: :signed_in?, only: %i[verify authenticate]
+  # TODO: VERIFY WHAT SESSIONS CONTROLLER DOES!
+  before_action :redirect_to_mfa, if: :mfa_required?
   before_action :ensure_not_blocked, only: :create
 
   def create

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,5 +1,6 @@
 class SettingsController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?
+  before_action :redirect_to_mfa, if: :mfa_required?
   before_action :set_cache_headers
 
   def edit

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -2,6 +2,8 @@ class Rubygem < ApplicationRecord
   include Patterns
   include RubygemSearchable
 
+  MOST_DOWNLOADED = 100
+
   has_many :ownerships, -> { confirmed }, dependent: :destroy, inverse_of: :rubygem
   has_many :ownerships_including_unconfirmed, dependent: :destroy, class_name: "Ownership"
   has_many :owners, through: :ownerships, source: :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,6 +228,11 @@ class User < ApplicationRecord
     otp_verified?(otp)
   end
 
+  def mfa_required?
+    return false if mfa_enabled?
+    owner_of_most_downloaded_gem?
+  end
+
   def otp_verified?(otp)
     otp = otp.to_s
     return true if verify_digit_otp(mfa_seed, otp)
@@ -289,5 +294,9 @@ class User < ApplicationRecord
     toxic = toxic_domains_path.exist? && toxic_domains_path.readlines.grep(/^#{Regexp.escape(domain)}$/).any?
 
     errors.add(:email, I18n.t("activerecord.errors.messages.blocked", domain: domain)) if toxic
+  end
+
+  def owner_of_most_downloaded_gem?
+    (rubygems & Rubygem.by_downloads.limit(Rubygem::MOST_DOWNLOADED)).any?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -233,6 +233,13 @@ class User < ApplicationRecord
     owner_of_most_downloaded_gem?
   end
 
+  # NOTE:
+  # Do we want to differentiate the concept of mfa required for an acct where mfa is not enabled vs.
+  # Identifying which accounts require mfa, regardless whether it's enabled or not
+  def owner_of_most_downloaded_gem?
+    (rubygems & Rubygem.by_downloads.limit(Rubygem::MOST_DOWNLOADED)).any?
+  end
+
   def otp_verified?(otp)
     otp = otp.to_s
     return true if verify_digit_otp(mfa_seed, otp)
@@ -294,9 +301,5 @@ class User < ApplicationRecord
     toxic = toxic_domains_path.exist? && toxic_domains_path.readlines.grep(/^#{Regexp.escape(domain)}$/).any?
 
     errors.add(:email, I18n.t("activerecord.errors.messages.blocked", domain: domain)) if toxic
-  end
-
-  def owner_of_most_downloaded_gem?
-    (rubygems & Rubygem.by_downloads.limit(Rubygem::MOST_DOWNLOADED)).any?
   end
 end

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -10,7 +10,8 @@
          <%= select_tag :level, options_for_select([
           [t(".mfa.level.ui_and_api"), "ui_and_api"],
           [t(".mfa.level.ui_and_gem_signin"), "ui_and_gem_signin"],
-          [t(".mfa.level.ui_only"), "ui_only"]], @user.mfa_level), class: "form__input form__select" %>
+          [t(".mfa.level.ui_only"), "ui_only"],
+          ["Deregister device", "disabled"]], @user.mfa_level), class: "form__input form__select" %>
       <% else %>
         <%= select_tag :level, options_for_select([
           [t(".mfa.level.ui_and_api"), "ui_and_api"],
@@ -22,7 +23,16 @@
         <%= label_tag :otp, "OTP code", class: "form__label" %>
         <%= text_field_tag :otp, "", class: "form__input", autocomplete: :off %>
       </div>
-      <%= submit_tag t(".mfa.update"), class: "form__submit" %>
+
+      <%# Note: Scrappy version ... this can obviously be DRY'd up %>
+      <% if @user.owner_of_most_downloaded_gem? %>
+        <%= submit_tag
+          t(".mfa.update"),
+          class: "form__submit",
+          data: { confirm: "✋ You will need to register a new device if you deregister the current device.\n\nDo you want to proceed?" } %>
+      <% else %>
+        <%= submit_tag t(".mfa.update"), class: "form__submit" %>
+      <% end %>
     <% end %>
   <% else %>
     <p>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -1,16 +1,23 @@
 <% @title = t(".title") %>
-
 <div class="t-body">
   <h2><%= t ".mfa.multifactor_auth" %></h2>
   <% if @user.mfa_enabled? %>
     <p><%= t(".mfa.enabled_html") %></p>
     <%= form_tag multifactor_auth_path, method: :put, id: "mfa-edit" do %>
       <%= label_tag :level, t(".mfa.level.title"), class: "form__label" %>
-      <%= select_tag :level, options_for_select([
-        [t(".mfa.level.ui_and_api"), "ui_and_api"],
-        [t(".mfa.level.ui_and_gem_signin"), "ui_and_gem_signin"],
-        [t(".mfa.level.ui_only"), "ui_only"],
-        [t(".mfa.level.disabled"), "disabled"]], @user.mfa_level), class: "form__input form__select" %>
+      <%# Note: Scrappy version ... this can obviously be DRY'd up %>
+      <% if @user.owner_of_most_downloaded_gem? %>
+         <%= select_tag :level, options_for_select([
+          [t(".mfa.level.ui_and_api"), "ui_and_api"],
+          [t(".mfa.level.ui_and_gem_signin"), "ui_and_gem_signin"],
+          [t(".mfa.level.ui_only"), "ui_only"]], @user.mfa_level), class: "form__input form__select" %>
+      <% else %>
+        <%= select_tag :level, options_for_select([
+          [t(".mfa.level.ui_and_api"), "ui_and_api"],
+          [t(".mfa.level.ui_and_gem_signin"), "ui_and_gem_signin"],
+          [t(".mfa.level.ui_only"), "ui_only"],
+          [t(".mfa.level.disabled"), "disabled"]], @user.mfa_level), class: "form__input form__select" %>
+      <% end %>
       <div class="text_field">
         <%= label_tag :otp, "OTP code", class: "form__label" %>
         <%= text_field_tag :otp, "", class: "form__input", autocomplete: :off %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -10,7 +10,6 @@
          <%= select_tag :level, options_for_select([
           [t(".mfa.level.ui_and_api"), "ui_and_api"],
           [t(".mfa.level.ui_and_gem_signin"), "ui_and_gem_signin"],
-          [t(".mfa.level.ui_only"), "ui_only"],
           ["Deregister device", "disabled"]], @user.mfa_level), class: "form__input form__select" %>
       <% else %>
         <%= select_tag :level, options_for_select([

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -148,6 +148,24 @@ class UserTest < ActiveSupport::TestCase
         assert_contains user.errors[:password], "has previously appeared in a data breach and should not be used"
       end
     end
+
+    context "two factor authentication" do
+      context "ui only" do
+        should "be invalid when user owns a most popular gem" do
+          user = create(:user)
+          my_rubygem = create(:rubygem)
+          create(:ownership, user: user, rubygem: my_rubygem)
+          assert_equal [my_rubygem], user.rubygems
+
+          GemDownload.increment(1, rubygem_id: my_rubygem.id)
+
+          assert user.owner_of_most_downloaded_gem?
+
+          refute user.update(mfa_level: "ui_only")
+          assert_contains user.errors[:mfa_level], "'UI only' MFA is not acceptable for owners of top-most downloaded gems"
+        end
+      end
+    end
   end
 
   context "with a user" do


### PR DESCRIPTION
Contributes to https://github.com/Shopify/code-foundations/issues/166

## 🛠️ Prototypes
We spiked 3 different approaches for implementing _enforcing MFA for owners of top 100 downloaded gems_:

**Option 1️⃣ PR: [Programmatic - dynamically determine owners of top 100 gems](https://github.com/Shopify/rubygems.org/pull/2)** 
☝️ This is the current PR. In this implementation, we're dynamically determining whether a user should have the MFA requirement enforced on their accounts. The risk to this approach is that MFA requirements may change day-to-day (or even minute-by-minute). For example, it's possible for gems along the edge of the "top 100 gems" threshold (e.g. gem ranked 99, 100, 101, 102 etc.) to change positions. This presents an inconsistency for whether certain accounts require mfa or not.  

Option 2️⃣ PR: [Add database column (boolean) - identify mfa-required users by mfa_required field](https://github.com/Shopify/rubygems.org/pull/6)

Option 3️⃣ PR: [Add database column (date) - provide an mfa enrolment deadline, upon deadline mfa enforcement becomes a requirement](https://github.com/Shopify/rubygems.org/pull/8)


## 🧪 What problem does this prototype solve?
Please refer to 

**TL;DR – This prototype requires owners of the top 100 downloaded gems to enable MFA.** Once enabled, those users will not be able to disable MFA. They can however, deregister a device and register with a new one. However, they will not be able to access any other views on `rubygems.org` that require authentication until MFA is enabled. 

---

Account takeovers is second most common vulnerability that's exploited. In enforcing MFA, we add more friction and increase complexity of successfully exploiting that vulnerability.

In an ideal world, all accounts registered on `rubygems.org` require MFA. Recognizing that policy may require a lot more change management efforts for all stakeholders to be bought-in, we brainstormed options that'll get us from 1 to 2, as opposed to 1 to 10. 

And so, instead of enforcing MFA on _everyone_, an incremental approach could be to target the highest-risk accounts. We identify higher risk accounts as `accounts belonging to users who are owners of the top 100 most downloaded gems`, since the blast radius of a nefarious actor taking over high risk accounts is quite large. 

## 🧬 How does this prototype work?
This introduces 3 different distinct user flows:

🔹 **When a user is an owner of a top 100 gem, with MFA disabled**
Once the user signs in to `rubygems.org`, they are redirected to the MFA set up view. All views that require authentication will not be accessible to the user until MFA is set up. They will still be able to view any publicly accessible views that do not require authentication.

The option to disable MFA is removed for these users. However, if they want to switch their authentication device, they can deregister the current device, and register a new one. Once their current device is deregistered, they cannot access any views that require authentication until they register their new device.

⚠️ The risk here is that it's possible for a user to deregister their device, technically disabling MFA. And, if they do not follow through with the second step of registering a new device, their account is once again _more vulnerable_ to account takeover attacks.

🎬 Demo: User flow of a top gem owner without MFA enabled

https://user-images.githubusercontent.com/4270287/149182021-376e44cb-b484-4ee9-96fe-aa1446659d0c.mov

🎬 Demo: User flow of a top gem owner deregistering their device (thereby disabling MFA)

https://user-images.githubusercontent.com/4270287/149188379-2a2602ce-de60-400c-9ddc-696f4e8c8137.mov


🔹 **When a user is an owner of a top 100 gem, with MFA enabled**
This is the happy path! Once the user signs in to `ruybgems.org`, they can access all the views.

🎬 Demo: User flow of a top gem owner setting up MFA

https://user-images.githubusercontent.com/4270287/149187258-67e9be42-495f-41f8-bb50-e44e5e004063.mov

🎬 Demo: User flow of a top gem owner signing in with MFA already enabled

https://user-images.githubusercontent.com/4270287/149187236-eb39b4ed-bd60-427e-bd3a-e91a143900a2.mov


🔹 **When a user is not an owner of a top 100 gem**
There are no changes to this user's experience on `rubygems.org`, as they are not in the cohort this prototype is proposing to enforce MFA on.

🎬 Demo: User flow for users who are not owners of a top 100 gem

https://user-images.githubusercontent.com/4270287/149189785-949d1f37-8f40-4966-8d33-45cd46ee6aba.mov

## 📝 Other notes
* This prototype only focuses on the UI experience and not CLI.