### PR TITLE
🧑‍🔬 Prototype: MFA Landing Page 

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -51,7 +51,11 @@ class SessionsController < Clearance::SessionsController
     sign_in(@user) do |status|
       if status.success?
         StatsD.increment "login.success"
-        redirect_back_or(url_after_create)
+        if @user.mfa_enabled?
+          redirect_back_or(url_after_create)
+        else
+          redirect_to new_multifactor_auth_path
+        end
       else
         login_failure(status.failure_message)
       end


### PR DESCRIPTION
Draft PR - Description is WIP. Work is WIP.

After sign in, redirect users to MFA view as their landing page to passively remind users to set up MFA.

Actively working on:
- User who does not have MFA enabled is redirected to MFA page after sign in ... ✅ yay!
- User who has MFA enabled is also redirected to MFA page (`settings/edit`), 🙅‍♀️ not the desired effect