### PR TITLE
🧑‍🔬 Prototype: Encourage MFA for owners of top 100 downloaded gems (CLI)

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -43,8 +43,8 @@ class Api::BaseController < ApplicationController
 
   def response_with_mfa_warning(response)
     return response unless should_setup_mfa? 
-    message = "[WARNING] For protection of your account and gems, we encourage you to setup multifactor authentication at https://rubygems.org/multifactor_auth/new. Your account will be required have MFA enabled in the future.\n\n"
-    message + response
+    message = "\n\n[WARNING] For protection of your account and gems, it is encouraged that you to set up multi-factor authentication at https://rubygems.org/multifactor_auth/new.\nYour account will be required have MFA enabled in the future."
+    response + message
   end
 
   def authenticate_with_api_key

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -43,7 +43,7 @@ class Api::BaseController < ApplicationController
 
   def response_with_mfa_warning(response)
     return response unless should_setup_mfa? 
-    message = "\n\n[WARNING] For protection of your account and gems, it is encouraged that you to set up multi-factor authentication at https://rubygems.org/multifactor_auth/new.\nYour account will be required have MFA enabled in the future."
+    message = "\n\n[WARNING] For protection of your account and your gems, you are encouraged to set up multi-factor authentication at https://rubygems.org/multifactor_auth/new.\nYour account will be required have MFA enabled in the future."
     response + message
   end
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -37,6 +37,16 @@ class Api::BaseController < ApplicationController
     render plain: "Gem requires MFA enabled; You do not have MFA enabled yet.", status: :forbidden
   end
 
+  def should_setup_mfa?
+    @api_key.user&.mfa_required?
+  end
+
+  def response_with_mfa_warning(response)
+    return response unless should_setup_mfa? 
+    message = "[WARNING] For protection of your account and gems, we encourage you to setup multifactor authentication at https://rubygems.org/multifactor_auth/new. Your account will be required have MFA enabled in the future.\n\n"
+    message + response
+  end
+
   def authenticate_with_api_key
     params_key = request.headers["Authorization"] || ""
     hashed_key = Digest::SHA256.hexdigest(params_key)

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::DeletionsController < Api::BaseController
     else
       StatsD.increment "yank.failure"
       render plain: response_with_mfa_warning(@deletion.errors.full_messages.to_sentence),
-              status: :unprocessable_entity
+             status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -11,11 +11,12 @@ class Api::V1::DeletionsController < Api::BaseController
     if @deletion.save
       StatsD.increment "yank.success"
       enqueue_web_hook_jobs(@version)
-      render plain: "Successfully deleted gem: #{@version.to_title}"
+      response_with_mfa_warning("Successfully deleted gem: #{@version.to_title}")
+      render plain: message
     else
       StatsD.increment "yank.failure"
-      render plain: @deletion.errors.full_messages.to_sentence,
-             status: :unprocessable_entity
+      render plain: response_with_mfa_warning(@deletion.errors.full_messages.to_sentence),
+              status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -11,8 +11,7 @@ class Api::V1::DeletionsController < Api::BaseController
     if @deletion.save
       StatsD.increment "yank.success"
       enqueue_web_hook_jobs(@version)
-      response_with_mfa_warning("Successfully deleted gem: #{@version.to_title}")
-      render plain: message
+      render plain: response_with_mfa_warning("Successfully deleted gem: #{@version.to_title}")
     else
       StatsD.increment "yank.failure"
       render plain: response_with_mfa_warning(@deletion.errors.full_messages.to_sentence),

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -20,13 +20,13 @@ class Api::V1::OwnersController < Api::BaseController
       ownership = @rubygem.ownerships.new(user: owner, authorizer: @api_key.user)
       if ownership.save
         Delayed::Job.enqueue(OwnershipConfirmationMailer.new(ownership.id))
-        render plain: "#{owner.display_handle} was added as an unconfirmed owner. "\
-                      "Ownership access will be enabled after the user clicks on the confirmation mail sent to their email."
+        render plain: response_with_mfa_warning("#{owner.display_handle} was added as an unconfirmed owner. "\
+                      "Ownership access will be enabled after the user clicks on the confirmation mail sent to their email.")
       else
-        render plain: ownership.errors.full_messages.to_sentence, status: :unprocessable_entity
+        render plain: response_with_mfa_warning(ownership.errors.full_messages.to_sentence), status: :unprocessable_entity
       end
     else
-      render plain: "Owner could not be found.", status: :not_found
+      render plain: response_with_mfa_warning("Owner could not be found."), status: :not_found
     end
   end
 
@@ -38,12 +38,12 @@ class Api::V1::OwnersController < Api::BaseController
       ownership = @rubygem.ownerships_including_unconfirmed.find_by(user_id: owner.id)
       if ownership.safe_destroy
         OwnersMailer.delay.owner_removed(ownership.user_id, @api_key.user.id, ownership.rubygem_id)
-        render plain: "Owner removed successfully."
+        render plain: response_with_mfa_warning("Owner removed successfully.")
       else
-        render plain: "Unable to remove owner.", status: :forbidden
+        render plain: response_with_mfa_warning("Unable to remove owner."), status: :forbidden
       end
     else
-      render plain: "Owner could not be found.", status: :not_found
+      render plain: response_with_mfa_warning("Owner could not be found."), status: :not_found
     end
   end
 

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,9 +1,23 @@
 class Api::V1::ProfilesController < Api::BaseController
+  before_action :set_user, only: [:show]
+
   def show
-    @user = User.find_by_slug!(params[:id])
     respond_to do |format|
       format.json { render json: @user }
       format.yaml { render yaml: @user }
     end
+  end
+
+  private
+
+  def set_user
+    @user =
+      if params[:id]
+        User.find_by_slug!(params[:id])
+      else
+        authenticate_or_request_with_http_basic do |username, password|
+          User.authenticate(username.strip, password)
+        end
+      end
   end
 end

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -31,10 +31,10 @@ class Api::V1::RubygemsController < Api::BaseController
 
     gemcutter = Pusher.new(@api_key.user, request.body, request.remote_ip)
     enqueue_web_hook_jobs(gemcutter.version) if gemcutter.process
-    render plain: gemcutter.message, status: gemcutter.code
+    render plain: response_with_mfa_warning(gemcutter.message), status: gemcutter.code
   rescue => e
     Honeybadger.notify(e)
-    render plain: "Server error. Please try again.", status: :internal_server_error
+    render plain: response_with_mfa_warning("Server error. Please try again."), status: :internal_server_error
   end
 
   def reverse_dependencies

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -2,7 +2,7 @@ class Rubygem < ApplicationRecord
   include Patterns
   include RubygemSearchable
 
-  MOST_DOWNLOADED = 100
+  TOP_N_MOST_DOWNLOADED = 100
 
   has_many :ownerships, -> { confirmed }, dependent: :destroy, inverse_of: :rubygem
   has_many :ownerships_including_unconfirmed, dependent: :destroy, class_name: "Ownership"

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -2,6 +2,8 @@ class Rubygem < ApplicationRecord
   include Patterns
   include RubygemSearchable
 
+  MOST_DOWNLOADED = 100
+
   has_many :ownerships, -> { confirmed }, dependent: :destroy, inverse_of: :rubygem
   has_many :ownerships_including_unconfirmed, dependent: :destroy, class_name: "Ownership"
   has_many :owners, through: :ownerships, source: :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,6 +228,19 @@ class User < ApplicationRecord
     otp_verified?(otp)
   end
 
+  # Copied from https://github.com/Shopify/rubygems.org/pull/2/files
+  def mfa_required?
+    return false if mfa_enabled?
+    owner_of_most_downloaded_gem?
+  end
+
+  # NOTE:
+  # Do we want to differentiate the concept of mfa required for an acct where mfa is not enabled vs.
+  # Identifying which accounts require mfa, regardless whether it's enabled or not
+  def owner_of_most_downloaded_gem?
+    (rubygems & Rubygem.by_downloads.limit(Rubygem::MOST_DOWNLOADED)).any?
+  end
+
   def otp_verified?(otp)
     otp = otp.to_s
     return true if verify_digit_otp(mfa_seed, otp)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -238,7 +238,7 @@ class User < ApplicationRecord
   # Do we want to differentiate the concept of mfa required for an acct where mfa is not enabled vs.
   # Identifying which accounts require mfa, regardless whether it's enabled or not
   def owner_of_most_downloaded_gem?
-    (rubygems & Rubygem.by_downloads.limit(Rubygem::MOST_DOWNLOADED)).any?
+    (rubygems & Rubygem.by_downloads.limit(Rubygem::TOP_N_MOST_DOWNLOADED)).any?
   end
 
   def otp_verified?(otp)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,7 +116,7 @@ class User < ApplicationRecord
   end
 
   def payload
-    attrs = { "id" => id, "handle" => handle }
+    attrs = { "id" => id, "handle" => handle, "mfa" => mfa_level }
     attrs["email"] = email unless hide_email
     attrs
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       end
       resource :multifactor_auth, only: :show
       resources :profiles, only: :show
+      resource :profile, only: :show
       resources :downloads, only: :index do
         get :top, on: :collection
         get :all, on: :collection

--- a/test/functional/api/v1/profiles_controller_test.rb
+++ b/test/functional/api/v1/profiles_controller_test.rb
@@ -18,6 +18,10 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
     send("to_#{@format}", @response.body)
   end
 
+  def authorize_with(str)
+    @request.env["HTTP_AUTHORIZATION"] = "Basic #{Base64.encode64(str)}"
+  end
+
   %i[json yaml].each do |format|
     context "when using #{format}" do
       setup do
@@ -40,6 +44,40 @@ class Api::V1::ProfilesControllerTest < ActionController::TestCase
         should respond_with :success
         should "hide the user email by default" do
           refute response_body.key?("email")
+        end
+      end
+
+      context "on GET to show with authentication" do
+        setup do
+          @user = create(:user)
+          authorize_with("#{@user.email}:#{@user.password}")
+          get :show, format: format
+        end
+
+        should respond_with :success
+      end
+
+      context "on GET to show with bad creds" do
+        setup do
+          @user = create(:user)
+          authorize_with("bad:creds")
+          get :show, format: format
+        end
+
+        should "deny access" do
+          assert_response 401
+          assert_match "HTTP Basic: Access denied.", @response.body
+        end
+      end
+
+      context "on GET to show with no params and no creds" do
+        setup do
+          get :show, format: format
+        end
+
+        should "deny access" do
+          assert_response 401
+          assert_match "HTTP Basic: Access denied.", @response.body
         end
       end
 


### PR DESCRIPTION
## Overview
This prototype relates to the stage of encouraging users to setup mfa in the proposed policy. The regular response is sent back with signin, push/yank gems, and add/remove owners actions along with a message (or warning) to encourage users to set up MFA.

### Gem signin
This requires changes to the rubygems' `gem signin command` as the response from the rubygems.org API when creating an API key is the [API key itself](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/gemcutter_utilities.rb#L176). Before creating an API key, an request is sent to `api/v1/profile` determine if MFA is enabled on the account, and if not, a message gets shown (see https://github.com/Shopify/rubygems/pull/1). This applies to _all users_ and not the targetted ones. 

<img width="1141" alt="Screen Shot 2021-12-16 at 10 18 43 AM" src="https://user-images.githubusercontent.com/42748004/146398406-d543fcdf-cc2f-4fee-b9b7-bf760a6c839b.png">

### Gem push/yank gems, and add/remove owners
A message is appended to the end of the response body of these commands. A warning cannot be appended before since these commands can check the beginning of the response body to determine certain states (eg. [mfa unauthorized](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/gemcutter_utilities.rb#L121)). This applies to users that have been targetted via the `mfa_required?` method (ie. most downloaded gem owners) on the user.

<img width="1147" alt="Screen Shot 2021-12-16 at 10 28 23 AM" src="https://user-images.githubusercontent.com/42748004/146399975-7fce271f-2ada-4b56-bd96-fd6a050a942b.png">

