### PR TITLE
🧑‍🔬 Prototype: Enforcing MFA for owners of top 100 downloaded gems (UI) (Option 2️⃣ )

### DIFF
--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -1,7 +1,7 @@
 class ApiKeysController < ApplicationController
   include ApiKeyable
   before_action :redirect_to_signin, unless: :signed_in?
-  before_action :redirect_to_mfa, if: :mfa_required?
+  before_action :redirect_to_mfa, if: :mfa_non_compliant?
   before_action :redirect_to_verify, unless: :password_session_active?
 
   def index

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,8 +49,8 @@ class ApplicationController < ActionController::Base
     redirect_to sign_in_path, alert: t("please_sign_in")
   end
 
-  def mfa_required?
-    current_user&.mfa_required?
+  def mfa_non_compliant?
+    current_user&.mfa_non_compliant?
   end
 
   def redirect_to_mfa

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,6 +1,6 @@
 class DashboardsController < ApplicationController
   before_action :authenticate_with_api_key, unless: :signed_in?
-  before_action :redirect_to_mfa, if: :mfa_required?
+  before_action :redirect_to_mfa, if: :mfa_non_compliant?
   before_action :redirect_to_signin, unless: -> { signed_in? || @api_key&.can_show_dashboard? }
 
   def show

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -1,7 +1,7 @@
 class EmailConfirmationsController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?, only: :unconfirmed
   # TODO: THINK ABOUT THE UNCONFIRMED FLOW
-  before_action :redirect_to_mfa, if: :mfa_required?
+  before_action :redirect_to_mfa, if: :mfa_non_compliant?
   before_action :validate_confirmation_token, only: %i[update mfa_update]
 
   def update

--- a/app/controllers/notifiers_controller.rb
+++ b/app/controllers/notifiers_controller.rb
@@ -1,6 +1,6 @@
 class NotifiersController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?
-  before_action :redirect_to_mfa, if: :mfa_required?
+  before_action :redirect_to_mfa, if: :mfa_non_compliant?
 
   def show
     @ownerships = current_user.ownerships.by_indexed_gem_name

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,6 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?, except: :show
-  before_action :redirect_to_mfa, if: :mfa_required?, except: :show
+  before_action :redirect_to_mfa, if: :mfa_non_compliant?, except: :show
   before_action :verify_password, only: %i[update destroy]
   before_action :set_cache_headers, only: :edit
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,6 @@
 class SessionsController < Clearance::SessionsController
   before_action :redirect_to_signin, unless: :signed_in?, only: %i[verify authenticate]
-  # TODO: VERIFY WHAT SESSIONS CONTROLLER DOES!
-  before_action :redirect_to_mfa, if: :mfa_required?
+  before_action :redirect_to_mfa, if: :mfa_non_compliant?
   before_action :ensure_not_blocked, only: :create
 
   def create

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,6 +1,6 @@
 class SettingsController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?
-  before_action :redirect_to_mfa, if: :mfa_required?
+  before_action :redirect_to_mfa, if: :mfa_non_compliant?
   before_action :set_cache_headers
 
   def edit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -229,9 +229,8 @@ class User < ApplicationRecord
     otp_verified?(otp)
   end
 
-  def mfa_required?
-    return false if mfa_enabled?
-    owner_of_most_downloaded_gem?
+  def mfa_non_compliant?
+    mfa_required? && !mfa_enabled?
   end
 
   # NOTE:

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -6,7 +6,7 @@
     <%= form_tag multifactor_auth_path, method: :put, id: "mfa-edit" do %>
       <%= label_tag :level, t(".mfa.level.title"), class: "form__label" %>
       <%# Note: Scrappy version ... this can obviously be DRY'd up %>
-      <% if @user.owner_of_most_downloaded_gem? %>
+      <% if @user.mfa_required? %>
          <%= select_tag :level, options_for_select([
           [t(".mfa.level.ui_and_api"), "ui_and_api"],
           [t(".mfa.level.ui_and_gem_signin"), "ui_and_gem_signin"],
@@ -24,7 +24,7 @@
       </div>
 
       <%# Note: Scrappy version ... this can obviously be DRY'd up %>
-      <% if @user.owner_of_most_downloaded_gem? %>
+      <% if @user.mfa_required? %>
         <%= submit_tag
           t(".mfa.update"),
           class: "form__submit",

--- a/db/migrate/20220107184633_add_mfa_required_to_users.rb
+++ b/db/migrate/20220107184633_add_mfa_required_to_users.rb
@@ -1,0 +1,5 @@
+class AddMfaRequiredToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :mfa_required, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_09_134738) do
+ActiveRecord::Schema.define(version: 2022_01_07_184633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -59,13 +59,13 @@ ActiveRecord::Schema.define(version: 2021_10_09_134738) do
   end
 
   create_table "dependencies", id: :serial, force: :cascade do |t|
-    t.string "requirements"
+    t.string "requirements", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "rubygem_id"
     t.integer "version_id"
-    t.string "scope"
-    t.string "unresolved_name"
+    t.string "scope", limit: 255
+    t.string "unresolved_name", limit: 255
     t.index ["rubygem_id"], name: "index_dependencies_on_rubygem_id"
     t.index ["unresolved_name"], name: "index_dependencies_on_unresolved_name"
     t.index ["version_id"], name: "index_dependencies_on_version_id"
@@ -89,12 +89,12 @@ ActiveRecord::Schema.define(version: 2021_10_09_134738) do
 
   create_table "linksets", id: :serial, force: :cascade do |t|
     t.integer "rubygem_id"
-    t.string "home"
-    t.string "wiki"
-    t.string "docs"
-    t.string "mail"
-    t.string "code"
-    t.string "bugs"
+    t.string "home", limit: 255
+    t.string "wiki", limit: 255
+    t.string "docs", limit: 255
+    t.string "mail", limit: 255
+    t.string "code", limit: 255
+    t.string "bugs", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["rubygem_id"], name: "index_linksets_on_rubygem_id"
@@ -128,10 +128,10 @@ ActiveRecord::Schema.define(version: 2021_10_09_134738) do
   end
 
   create_table "rubygems", id: :serial, force: :cascade do |t|
-    t.string "name"
+    t.string "name", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "slug"
+    t.string "slug", limit: 255
     t.boolean "indexed", default: false, null: false
     t.index "regexp_replace(upper((name)::text), '[_-]'::text, ''::text, 'g'::text)", name: "dashunderscore_typos_idx"
     t.index "upper((name)::text) varchar_pattern_ops", name: "index_rubygems_upcase"
@@ -184,6 +184,7 @@ ActiveRecord::Schema.define(version: 2021_10_09_134738) do
     t.string "mfa_recovery_codes", default: [], array: true
     t.integer "mail_fails", default: 0
     t.string "blocked_email"
+    t.boolean "mfa_required", default: false, null: false
     t.index ["email"], name: "index_users_on_email"
     t.index ["handle"], name: "index_users_on_handle"
     t.index ["id", "confirmation_token"], name: "index_users_on_id_and_confirmation_token"
@@ -195,31 +196,31 @@ ActiveRecord::Schema.define(version: 2021_10_09_134738) do
   create_table "versions", id: :serial, force: :cascade do |t|
     t.text "authors"
     t.text "description"
-    t.string "number"
+    t.string "number", limit: 255
     t.integer "rubygem_id"
     t.datetime "built_at"
     t.datetime "updated_at"
     t.text "summary"
-    t.string "platform"
+    t.string "platform", limit: 255
     t.datetime "created_at"
     t.boolean "indexed", default: true
     t.boolean "prerelease"
     t.integer "position"
     t.boolean "latest"
-    t.string "full_name"
+    t.string "full_name", limit: 255
+    t.string "licenses", limit: 255
     t.integer "size"
-    t.string "licenses"
     t.text "requirements"
-    t.string "required_ruby_version"
-    t.string "sha256"
+    t.string "required_ruby_version", limit: 255
+    t.string "sha256", limit: 255
     t.hstore "metadata", default: {}, null: false
-    t.datetime "yanked_at"
     t.string "required_rubygems_version", limit: 255
+    t.datetime "yanked_at"
     t.string "info_checksum"
     t.string "yanked_info_checksum"
     t.bigint "pusher_id"
-    t.text "cert_chain"
     t.string "canonical_number"
+    t.text "cert_chain"
     t.index "lower((full_name)::text)", name: "index_versions_on_lower_full_name"
     t.index ["built_at"], name: "index_versions_on_built_at"
     t.index ["created_at"], name: "index_versions_on_created_at"

--- a/lib/tasks/mfa_required_for_user.rake
+++ b/lib/tasks/mfa_required_for_user.rake
@@ -1,0 +1,19 @@
+namespace :mfa_required_for_user do
+  desc "Set mfa required for owners of top 100 downloaded gems"
+  task top_gem_owners: :environment do
+    owners = User.joins(rubygems: :gem_download).order("gem_downloads.count DESC").limit(100).uniq
+
+    owners.each do |owner|
+      # if owner.mfa_required
+      #   puts "👌 #{owner.email} is already required"
+      #   next
+      # end
+
+      next if owner.mfa_required
+
+      owner.update(mfa_required: true) 
+      puts "✅ update #{owner.email} to require mfa"
+    end
+  end
+end
+

--- a/script/mfa_required_for_user
+++ b/script/mfa_required_for_user
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+ENV["RAILS_ENV"] ||= "production"
+require_relative "../config/environment"
+
+owners = User.joins(rubygems: :gem_download).order("gem_downloads.count DESC").limit(100).uniq
+
+owners.each do |owner|
+  next if owner.mfa_required
+
+  owner.update(mfa_required: true) 
+  puts "update #{owner.email} to require mfa"
+end
+


### PR DESCRIPTION
Contributes to https://github.com/Shopify/code-foundations/issues/166

## 🧪 What problem does this prototype solve?
**TL;DR – This prototype requires owners of the top 100 downloaded gems to enable MFA.** Once enabled, those users will not be able to disable MFA. They can however, deregister a device and register with a new one. However, they will not be able to access any other views on `rubygems.org` that require authentication until MFA is enabled. 

---

Account takeovers is second most common vulnerability that's exploited. In enforcing MFA, we add more friction and increase complexity of successfully exploiting that vulnerability.

In an ideal world, all accounts registered on `rubygems.org` require MFA. Recognizing that policy may require a lot more change management efforts for all stakeholders to be bought-in, we brainstormed options that'll get us from 1 to 2, as opposed to 1 to 10. 

And so, instead of enforcing MFA on _everyone_, an incremental approach could be to target the highest-risk accounts. We identify higher risk accounts as `accounts belonging to users who are owners of the top 100 most downloaded gems`, since the blast radius of a nefarious actor taking over high risk accounts is quite large. 

## 🧬 How does this prototype work?
This introduces 3 different distinct user flows:

🔹 **When a user is an owner of a top 100 gem, with MFA disabled**
Once the user signs in to `rubygems.org`, they are redirected to the MFA set up view. All views that require authentication will not be accessible to the user until MFA is set up. They will still be able to view any publicly accessible views that do not require authentication.

The option to disable MFA is removed for these users. However, if they want to switch their authentication device, they can deregister the current device, and register a new one. Once their current device is deregistered, they cannot access any views that require authentication until they register their new device.

⚠️ The risk here is that it's possible for a user to deregister their device, technically disabling MFA. And, if they do not follow through with the second step of registering a new device, their account is once again _more vulnerable_ to account takeover attacks.

🔹 **When a user is an owner of a top 100 gem, with MFA enabled**
This is the happy path! Once the user signs in to `ruybgems.org`, they can access all the views.

🔹 **When a user is not an owner of a top 100 gem**
There are no changes to this user's experience on `rubygems.org`, as they are not in the cohort this prototype is proposing to enforce MFA on.

## 🤷‍♀️ How does this approach differ from option 1️⃣ 
In option 1️⃣ , the top 100 gem owners are determined dynamically.

The approach to this implementation is to add a `mfa_required` attribute to `users`. The benefits of this approach is that the MFA enforcement is consistent. There may be gems that fluctuate along the threshold "top 100", going from `#100` to `#101` for instance and vice versa. In the case where a gem falls out of range, but was once within the top 100, we'll continue to enforce MFA on their accounts. However, with this approach, we'll likely need to introduce some mechanism (e.g. scheduled job) to update the list of user accounts that should have MFA enforced. 


## 📝 Other notes
* This prototype only focuses on the UI experience and not CLI.