### PR TITLE
🧑‍🔬 Prototype: MFA for owners of top 100 downloaded gems (CLI)

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -37,6 +37,16 @@ class Api::BaseController < ApplicationController
     render plain: "Gem requires MFA enabled; You do not have MFA enabled yet.", status: :forbidden
   end
 
+  def should_setup_mfa?
+    @api_key.user&.recommend_mfa_setup?
+  end
+
+  def response_with_mfa_warning(response)
+    return response unless should_setup_mfa? 
+    message = "\n\n[WARNING] For protection of your account and your gems, you are encouraged to set up multi-factor authentication at https://rubygems.org/multifactor_auth/new. Your account will be required have MFA enabled in the future."
+    response + message
+  end
+
   def authenticate_with_api_key
     params_key = request.headers["Authorization"] || ""
     hashed_key = Digest::SHA256.hexdigest(params_key)

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -25,6 +25,11 @@ class Api::BaseController < ApplicationController
     end
   end
 
+  def check_user_mfa_requirement
+    return unless @api_key.user&.mfa_required?
+    render plain: t(:user_mfa_required), status: :forbidden
+  end
+
   def verify_with_otp
     otp = request.headers["HTTP_OTP"]
     return if @api_key.user.mfa_api_authorized?(otp)

--- a/app/controllers/api/v1/api_keys_controller.rb
+++ b/app/controllers/api/v1/api_keys_controller.rb
@@ -47,7 +47,9 @@ class Api::V1::ApiKeysController < Api::BaseController
   private
 
   def check_mfa(user)
-    if user&.mfa_gem_signin_authorized?(otp)
+    if user&.mfa_required?
+      render plain: t(:user_mfa_required), status: :forbidden
+    elsif user&.mfa_gem_signin_authorized?(otp)
       yield
     elsif user&.mfa_enabled?
       prompt_text = otp.present? ? t(:otp_incorrect) : t(:otp_missing)

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -11,10 +11,10 @@ class Api::V1::DeletionsController < Api::BaseController
     if @deletion.save
       StatsD.increment "yank.success"
       enqueue_web_hook_jobs(@version)
-      render plain: "Successfully deleted gem: #{@version.to_title}"
+      render plain: response_with_mfa_warning("Successfully deleted gem: #{@version.to_title}")
     else
       StatsD.increment "yank.failure"
-      render plain: @deletion.errors.full_messages.to_sentence,
+      render plain: response_with_mfa_warning(@deletion.errors.full_messages.to_sentence),
              status: :unprocessable_entity
     end
   end

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::DeletionsController < Api::BaseController
   before_action :verify_with_otp
   before_action :render_api_key_forbidden, if: :api_key_unauthorized?
   before_action :verify_mfa_requirement
+  before_action :check_user_mfa_requirement
 
   def create
     @deletion = @api_key.user.deletions.build(version: @version)

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -20,13 +20,13 @@ class Api::V1::OwnersController < Api::BaseController
       ownership = @rubygem.ownerships.new(user: owner, authorizer: @api_key.user)
       if ownership.save
         Delayed::Job.enqueue(OwnershipConfirmationMailer.new(ownership.id))
-        render plain: "#{owner.display_handle} was added as an unconfirmed owner. "\
-         "Ownership access will be enabled after the user clicks on the confirmation mail sent to their email."
+        render plain: response_with_mfa_warning("#{owner.display_handle} was added as an unconfirmed owner. "\
+         "Ownership access will be enabled after the user clicks on the confirmation mail sent to their email.")
       else
-        render plain: ownership.errors.full_messages.to_sentence, status: :unprocessable_entity
+        render plain: response_with_mfa_warning(ownership.errors.full_messages.to_sentence), status: :unprocessable_entity
       end
     else
-      render plain: "Owner could not be found.", status: :not_found
+      render plain: response_with_mfa_warning("Owner could not be found."), status: :not_found
     end
   end
 
@@ -38,12 +38,12 @@ class Api::V1::OwnersController < Api::BaseController
       ownership = @rubygem.ownerships_including_unconfirmed.find_by(user_id: owner.id)
       if ownership.safe_destroy
         OwnersMailer.delay.owner_removed(ownership.user_id, @api_key.user.id, ownership.rubygem_id)
-        render plain: "Owner removed successfully."
+        render plain: response_with_mfa_warning("Owner removed successfully.")
       else
-        render plain: "Unable to remove owner.", status: :forbidden
+        render plain: response_with_mfa_warning("Unable to remove owner."), status: :forbidden
       end
     else
-      render plain: "Owner could not be found.", status: :not_found
+      render plain: response_with_mfa_warning("Owner could not be found."), status: :not_found
     end
   end
 

--- a/app/controllers/api/v1/owners_controller.rb
+++ b/app/controllers/api/v1/owners_controller.rb
@@ -4,6 +4,7 @@ class Api::V1::OwnersController < Api::BaseController
   before_action :verify_gem_ownership, except: %i[show gems]
   before_action :verify_mfa_requirement, except: %i[show gems]
   before_action :verify_with_otp, except: %i[show gems]
+  before_action :check_user_mfa_requirement, except: %i[show gems]
 
   def show
     respond_to do |format|

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,9 +1,25 @@
 class Api::V1::ProfilesController < Api::BaseController
+  before_action :set_user, only: [:show]
+
   def show
-    @user = User.find_by_slug!(params[:id])
     respond_to do |format|
       format.json { render json: @user }
       format.yaml { render yaml: @user }
     end
+  end
+
+  private
+
+  def set_user
+    @user =
+      if params[:id]
+        User.find_by_slug!(params[:id])
+      else
+        authenticate_or_request_with_http_basic do |username, password|
+          if (user = User.authenticate(username.strip, password))
+            user.private_payload
+          end
+        end
+      end
   end
 end

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -31,10 +31,10 @@ class Api::V1::RubygemsController < Api::BaseController
 
     gemcutter = Pusher.new(@api_key.user, request.body, request.remote_ip)
     enqueue_web_hook_jobs(gemcutter.version) if gemcutter.process
-    render plain: gemcutter.message, status: gemcutter.code
+    render plain: response_with_mfa_warning(gemcutter.message), status: gemcutter.code
   rescue => e
     Honeybadger.notify(e)
-    render plain: "Server error. Please try again.", status: :internal_server_error
+    render plain: response_with_mfa_warning("Server error. Please try again."), status: :internal_server_error
   end
 
   def reverse_dependencies

--- a/app/controllers/api/v1/rubygems_controller.rb
+++ b/app/controllers/api/v1/rubygems_controller.rb
@@ -3,6 +3,7 @@ class Api::V1::RubygemsController < Api::BaseController
   before_action :find_rubygem,              only: %i[show reverse_dependencies]
   before_action :cors_preflight_check, only: :show
   before_action :verify_with_otp, only: %i[create]
+  before_action :check_user_mfa_requirement, only: %i[create]
   after_action  :cors_set_access_control_headers, only: :show
 
   def index

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,6 +122,10 @@ class User < ApplicationRecord
     attrs
   end
 
+  def private_payload
+    payload.merge("mfa" => mfa_level)
+  end
+
   def as_json(*)
     payload
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
   none: None
   not_found: Not Found
   api_key_forbidden: The API key doesn't have access
+  user_mfa_required: For protection of your account and your gems, please setup multi-factor authentication at https://rubygems.org/multifactor_auth/new
   please_sign_up: Access Denied. Please sign up for an account at https://rubygems.org
   please_sign_in: Please sign in to continue.
   otp_incorrect: Your OTP code is incorrect. Please check it and retry.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       end
       resource :multifactor_auth, only: :show
       resources :profiles, only: :show
+      resource :profile, only: :show
       resources :downloads, only: :index do
         get :top, on: :collection
         get :all, on: :collection


### PR DESCRIPTION
## Overview
Builds off of the UI flow https://github.com/Shopify/rubygems.org/pull/8

This prototype relates to the stage of encouraging users, and requiring users to set up mfa in the CLI. 

## User in the encouragement state
The regular response is sent back with signin, push/yank gems, and add/remove owners actions along with a message (or warning) to encourage users to set up MFA.

### Gem signin
This requires changes to the rubygems' `gem signin command` as the response from the rubygems.org API when creating an API key is the [API key itself](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/gemcutter_utilities.rb#L176). Before creating an API key, an request is sent to `api/v1/profile` determine if MFA is enabled on the account, and if not, a message gets shown (see https://github.com/Shopify/rubygems/pull/1). This applies to _all users_ and not the targetted ones. 

We could display it for targeted users however. This would require another field to be added to the profile for user messages or warnings ([rubygems.org](https://github.com/Shopify/rubygems.org/compare/encourage-mfa-cli-op3...Shopify:encourage-mfa-cli-gem-signin-alt?expand=1), [rubygems](https://github.com/Shopify/rubygems/compare/encourage-mfa-cli...Shopify:encourage-mfa-cli-alt?expand=1)). It might be worth adding this field to communicate info in future initiatives (eg. gem signing).

<img width="1149" alt="Screen Shot 2022-01-11 at 8 51 51 PM" src="https://user-images.githubusercontent.com/42748004/149051077-732a69bf-5770-4fd3-9270-9fe6301e33d2.png">

### Gem push/yank gems, and add/remove owners
A message is appended to the end of the response body of these commands. A warning cannot be appended before since these commands can check the beginning of the response body to determine certain states (eg. [mfa unauthorized](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/gemcutter_utilities.rb#L121)). This applies to users that have been targetted via the `mfa_required?` method (ie. most downloaded gem owners) on the user.

<img width="967" alt="Screen Shot 2022-01-11 at 9 01 44 PM" src="https://user-images.githubusercontent.com/42748004/149051071-148e9310-c9b2-46ab-9bc3-b7905895edff.png">

## User in the required state
When a user tries to signin, push/yank gems, and add/remove owners, a message renders to make the user setup MFA if the user doesn't have MFA enabled with the forbidden response. This is only limited to the accounts that is targeted by `mfa_required?`.

### Gem signin
Could make it so the signin exits early if we use the targeted user warning approach mentioned in gem signin in the encouraging phase. The warning field would store a list of warnings as well as if they should early exit (eg. `[{msg:"WARNING...", exit: true}, ...]`).
<img width="1170" alt="Screen Shot 2022-01-13 at 9 20 13 AM" src="https://user-images.githubusercontent.com/42748004/149347132-96203b05-b64d-493e-8beb-ff3953845f0e.png">

### Gem push
<img width="1114" alt="Screen Shot 2022-01-11 at 9 16 41 PM" src="https://user-images.githubusercontent.com/42748004/149051968-8ab38617-fc62-4ff1-8d85-82c6c6a51e42.png">
