### PR TITLE
🧑‍🔬 Prototype: Enforcing MFA for owners of top 100 downloaded gems (UI)

### DIFF
--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -2,6 +2,7 @@ class ApiKeysController < ApplicationController
   include ApiKeyable
   before_action :redirect_to_signin, unless: :signed_in?
   before_action :redirect_to_verify, unless: :password_session_active?
+  before_action :redirect_to_mfa, unless: :mfa_compliant?
 
   def index
     @api_key  = session.delete(:api_key)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,12 +49,18 @@ class ApplicationController < ActionController::Base
     redirect_to sign_in_path, alert: t("please_sign_in")
   end
 
+  def mfa_compliant?
+    current_user&.mfa_compliant?
+  end
+
   def mfa_setup_requested?
-    current_user&.mfa_setup_recommended?
+    current_user&.mfa_setup_recommended? || !mfa_compliant?
   end
 
   def redirect_to_mfa
-    redirect_to new_multifactor_auth_path, notice: "⚠️ #{t("multifactor_auths.setup_recommended")}"
+    message = !mfa_compliant? ? t("multifactor_auths.compliance_required") : t("multifactor_auths.setup_recommended")
+
+    redirect_to new_multifactor_auth_path, notice: "⚠️ #{message}"
   end
 
   def find_rubygem

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,6 +49,14 @@ class ApplicationController < ActionController::Base
     redirect_to sign_in_path, alert: t("please_sign_in")
   end
 
+  def mfa_setup_requested?
+    current_user&.mfa_setup_recommended?
+  end
+
+  def redirect_to_mfa
+    redirect_to new_multifactor_auth_path, notice: "⚠️ #{t("multifactor_auths.setup_recommended")}"
+  end
+
   def find_rubygem
     @rubygem = Rubygem.find_by_name(params[:rubygem_id] || params[:id])
     return if @rubygem

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,6 +1,7 @@
 class DashboardsController < ApplicationController
   before_action :authenticate_with_api_key, unless: :signed_in?
   before_action :redirect_to_signin, unless: -> { signed_in? || @api_key&.can_show_dashboard? }
+  before_action :redirect_to_mfa, unless: :mfa_compliant?
 
   def show
     respond_to do |format|

--- a/app/controllers/email_confirmations_controller.rb
+++ b/app/controllers/email_confirmations_controller.rb
@@ -1,5 +1,6 @@
 class EmailConfirmationsController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?, only: :unconfirmed
+  before_action :redirect_to_mfa, unless: :mfa_compliant?
   before_action :validate_confirmation_token, only: %i[update mfa_update]
 
   def update

--- a/app/controllers/notifiers_controller.rb
+++ b/app/controllers/notifiers_controller.rb
@@ -1,6 +1,7 @@
 class NotifiersController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?
-
+  before_action :redirect_to_mfa, unless: :mfa_compliant?
+  
   def show
     @ownerships = current_user.ownerships.by_indexed_gem_name
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,6 @@
 class ProfilesController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?, except: :show
+  before_action :redirect_to_mfa, unless: :mfa_compliant?
   before_action :verify_password, only: %i[update destroy]
   before_action :set_cache_headers, only: :edit
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -51,6 +51,8 @@ class SessionsController < Clearance::SessionsController
     sign_in(@user) do |status|
       if status.success?
         StatsD.increment "login.success"
+        return redirect_to_mfa if mfa_setup_requested?
+
         redirect_back_or(url_after_create)
       else
         login_failure(status.failure_message)

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,5 +1,6 @@
 class SettingsController < ApplicationController
   before_action :redirect_to_signin, unless: :signed_in?
+  before_action :redirect_to_mfa, unless: :mfa_compliant?
   before_action :set_cache_headers
 
   def edit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -239,6 +239,22 @@ class User < ApplicationRecord
     save!(validate: false)
   end
 
+  def mfa_required?
+    return false unless mfa_required_at
+
+    mfa_required_at < Time.now.utc 
+  end
+
+  def mfa_setup_recommended?
+    mfa_recommended? && !mfa_enabled?
+  end
+
+  def mfa_recommended?
+    return false if mfa_required?
+
+    mfa_required_at?
+  end
+
   def block!
     original_email = email
     transaction do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -255,6 +255,12 @@ class User < ApplicationRecord
     mfa_required_at?
   end
 
+  def mfa_compliant?
+    return true if !mfa_required? 
+
+    mfa_required? && mfa_enabled?
+  end
+
   def block!
     original_email = email
     transaction do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,6 +57,7 @@ class User < ApplicationRecord
     unless: :skip_password_validation?
   validate :unconfirmed_email_uniqueness
   validate :toxic_email_domain, on: :create
+  validate :minimum_acceptable_mfa_level, if: :mfa_level_changed?
 
   enum mfa_level: { disabled: 0, ui_only: 1, ui_and_api: 2, ui_and_gem_signin: 3 }, _prefix: :mfa
 
@@ -318,4 +319,15 @@ class User < ApplicationRecord
 
     errors.add(:email, I18n.t("activerecord.errors.messages.blocked", domain: domain)) if toxic
   end
+
+  def minimum_acceptable_mfa_level
+    if owner_of_most_downloaded_gem?
+      acceptable_levels = User.mfa_levels.keys - [ "ui_only" ]
+
+      unless acceptable_levels.include?(mfa_level)
+        errors.add(:mfa_level, "'UI only' MFA is not acceptable for owners of top-most downloaded gems")
+      end
+    end
+  end
+
 end

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -6,16 +6,31 @@
     <p><%= t(".mfa.enabled_html") %></p>
     <%= form_tag multifactor_auth_path, method: :put, id: "mfa-edit" do %>
       <%= label_tag :level, t(".mfa.level.title"), class: "form__label" %>
+      <%# Note: Scrappy version ... this can obviously be DRY'd up %>
+      <% if @user.mfa_required? && @user.mfa_enabled? %>
       <%= select_tag :level, options_for_select([
         [t(".mfa.level.ui_and_api"), "ui_and_api"],
         [t(".mfa.level.ui_and_gem_signin"), "ui_and_gem_signin"],
-        [t(".mfa.level.ui_only"), "ui_only"],
-        [t(".mfa.level.disabled"), "disabled"]], @user.mfa_level), class: "form__input form__select" %>
+        [t(".mfa.deregister_device"), "disabled"]], @user.mfa_level), class: "form__input form__select" %>
+      <% else %>
+        <%= select_tag :level, options_for_select([
+          [t(".mfa.level.ui_and_api"), "ui_and_api"],
+          [t(".mfa.level.ui_and_gem_signin"), "ui_and_gem_signin"],
+          [t(".mfa.level.ui_only"), "ui_only"],
+          [t(".mfa.level.disabled"), "disabled"]], @user.mfa_level), class: "form__input form__select" %>
+      <% end %>
       <div class="text_field">
         <%= label_tag :otp, "OTP code", class: "form__label" %>
         <%= text_field_tag :otp, "", class: "form__input", autocomplete: :off %>
       </div>
-      <%= submit_tag t(".mfa.update"), class: "form__submit" %>
+      <%# Note: Scrappy version ... this can obviously be DRY'd up %>
+      <% if @user.mfa_required? && @user.mfa_enabled? %>
+        <%= submit_tag t(".mfa.update"),
+          class: "form__submit",
+          data: { confirm: "✋ #{t(".mfa.deregister_confirmation")}" } %>
+      <% else %>
+        <%= submit_tag t(".mfa.update"), class: "form__submit" %>
+      <% end %>
     <% end %>
   <% else %>
     <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,6 +363,8 @@ en:
         multifactor_auth: Multifactor authentication
         disabled_html: You have not yet enabled multifactor authentication. Please refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
         go_settings: Register a new device
+        deregister_device: Deregister device
+        deregister_confirmation: You will need to register a new device if you deregister the current device. Do you want to proceed?
         enabled_html: You have enabled multifactor authentication. Please input your OTP from your authenticator or one of your active recovery codes to change your MFA level or disable it.
           Refer to <a target="_blank" href="https://guides.rubygems.org/setting-up-multifactor-authentication">RubyGems MFA guide</a> for more information on these levels.
         update: Update

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -281,6 +281,7 @@ en:
     recovery_code_html: 'You can use a valid  <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#using-recovery-codes-and-re-setup-a-previously-enabled-mfa", class="t-link">recovery code</a> if you have lost access to your MFA device.'
     incorrect_otp: Your OTP code is incorrect.
     otp_code: OTP code
+    setup_recommended: For protection of your account and your gems, we encourage you to set up multi-factor authentication.
     require_mfa_disabled: Your multifactor authentication has been enabled. You have to disable it first.
     require_mfa_enabled: Your multifactor authentication has not been enabled. You have to enable it first.
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -282,6 +282,7 @@ en:
     incorrect_otp: Your OTP code is incorrect.
     otp_code: OTP code
     setup_recommended: For protection of your account and your gems, we encourage you to set up multi-factor authentication.
+    compliance_required: For protection of your account and your gems, you are required to set up multi-factor authentication.
     require_mfa_disabled: Your multifactor authentication has been enabled. You have to disable it first.
     require_mfa_enabled: Your multifactor authentication has not been enabled. You have to enable it first.
     new:

--- a/db/migrate/20220113221326_add_mfa_required_at_to_users.rb
+++ b/db/migrate/20220113221326_add_mfa_required_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddMfaRequiredAtToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :mfa_required_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_30_050124) do
+ActiveRecord::Schema.define(version: 2022_01_13_221326) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -211,6 +211,7 @@ ActiveRecord::Schema.define(version: 2021_11_30_050124) do
     t.string "mfa_recovery_codes", default: [], array: true
     t.integer "mail_fails", default: 0
     t.string "blocked_email"
+    t.datetime "mfa_required_at"
     t.index ["email"], name: "index_users_on_email"
     t.index ["handle"], name: "index_users_on_handle"
     t.index ["id", "confirmation_token"], name: "index_users_on_id_and_confirmation_token"

--- a/script/require_mfa_for_users
+++ b/script/require_mfa_for_users
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+ENV["RAILS_ENV"] ||= "production"
+require_relative "../config/environment"
+
+mfa_required_at_date = Date.new(2022, 12, 31)
+owners = User.joins(rubygems: :gem_download).order("gem_downloads.count DESC").limit(100).uniq
+
+owners.each do |owner|
+  next if owner.mfa_required_at
+
+  owner.update(mfa_required_at: mfa_required_at_date) 
+  puts "✅ updated #{owner.email} to require mfa enrollment by #{mfa_required_at_date}"
+end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -148,6 +148,24 @@ class UserTest < ActiveSupport::TestCase
         assert_contains user.errors[:password], "has previously appeared in a data breach and should not be used"
       end
     end
+
+    context "two factor authentication" do
+      context "ui only" do
+        should "be invalid when user owns a most popular gem" do
+          user = create(:user)
+          my_rubygem = create(:rubygem)
+          create(:ownership, user: user, rubygem: my_rubygem)
+          assert_equal [my_rubygem], user.rubygems
+
+          GemDownload.increment(1, rubygem_id: my_rubygem.id)
+
+          assert user.owner_of_most_downloaded_gem?
+
+          refute user.update(mfa_level: "ui_only")
+          assert_contains user.errors[:mfa_level], "'UI only' MFA is not acceptable for owners of top-most downloaded gems"
+        end
+      end
+    end
   end
 
   context "with a user" do


### PR DESCRIPTION
Contributes to https://github.com/Shopify/code-foundations/issues/166

## 🧪 What problem does this prototype solve?
Please refer to the [RFC: Require MFA on the top 100 most downloaded gems](https://github.com/rubygems/rfcs/pull/36/files)

## 🛠 TL;DR on Technical Approach 
Note: This prototype represents the cumulation of various approaches that were spiked in previous prototypes:

* 🧬 [Programmatic - dynamically determine owners of top 100 gems](https://github.com/Shopify/rubygems.org/pull/2)

* 🧬 [Add database column (boolean) - identify mfa-required users by mfa_required field](https://github.com/Shopify/rubygems.org/pull/6)

* 🧬 [Add database column (date) - provide an mfa enrolment deadline, upon deadline mfa enforcement becomes a requirement](https://github.com/Shopify/rubygems.org/pull/8)

* 🧬 [Redirect _all_ users to MFA landing page if MFA is not enabled](https://github.com/Shopify/rubygems.org/pull/3)

This is the outline of the approach:
**🔹 Add `mfa_required_at` column to `users` table**
The date saved to this field will indicate when a user will have MFA enforced.

**🔹 Add script to enroll MFA for top 100 most downloaded gem owners**
When the script is run, it sets a date in the future for users identified as the top 100 most downloaded gem owners at that given moment.

**🔹 Redirects user to MFA page if account is flagged as `mfa_setup_recommended`**
If a user has an `mfa_required_at` date set in the future, they will be redirected to the MFA landing page upon logging into rubygems.org UI. A flash notice appears encouraging the user to set up MFA. The user can navigate away from the MFA landing page regardless of whether they enable MFA.

**🔹 Redirect users to MFA page if account is flagged as being non-compliant to MFA policy.**
If a user has an `mfa_required_at` date set in the future, they will be redirected to the MFA landing page upon logging into rubygems.org UI. A flash notice appears encouraging the user to set up MFA. The user can navigate away from the MFA landing page regardless of whether they enable MFA.

**🔹 For users with MFA enforced, they can deregister their device to set up a new one**
For users who are required to have MFA enabled, they have the option to deregister a device. For users with no MFA policy enforced, they can continue with the current user flow and disable MFA if it was enabled.

**🔹 Disallow `ui_only` MFA level for popular gem owners**
This removes the `ui_only` level from the api settings dropdown and blocks it on the backend if the user owns one of the 100 most downloaded gems.

## 🎬 Demos
Below are demos of various user flows

🎬 User flow of a top gem owner without MFA enabled

https://user-images.githubusercontent.com/4270287/149182021-376e44cb-b484-4ee9-96fe-aa1446659d0c.mov

🎬 User flow of a top gem owner deregistering their device (thereby disabling MFA)

https://user-images.githubusercontent.com/4270287/149188379-2a2602ce-de60-400c-9ddc-696f4e8c8137.mov

🎬 User flow of a top gem owner setting up MFA

https://user-images.githubusercontent.com/4270287/149187258-67e9be42-495f-41f8-bb50-e44e5e004063.mov

🎬 User flow of a top gem owner signing in with MFA already enabled

https://user-images.githubusercontent.com/4270287/149187236-eb39b4ed-bd60-427e-bd3a-e91a143900a2.mov

🎬 User flow for users who are not owners of a top 100 gem

https://user-images.githubusercontent.com/4270287/149189785-949d1f37-8f40-4966-8d33-45cd46ee6aba.mov