### PR TITLE
[Draft] MFA UI recommended phase

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,6 +49,14 @@ class ApplicationController < ActionController::Base
     redirect_to sign_in_path, alert: t("please_sign_in")
   end
 
+  def redirect_to_mfa_setup(**options)
+    redirect_to new_multifactor_auth_path, options
+  end
+
+  def redirect_to_settings(**options)
+    redirect_to edit_settings_path, options
+  end
+
   def find_rubygem
     @rubygem = Rubygem.find_by_name(params[:rubygem_id] || params[:id])
     return if @rubygem

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -51,6 +51,9 @@ class SessionsController < Clearance::SessionsController
     sign_in(@user) do |status|
       if status.success?
         StatsD.increment "login.success"
+        return redirect_to_mfa_setup(notice: t("multifactor_auths.setup_recommended")) if current_user.mfa_recommended_not_yet_enabled?
+        return redirect_to_settings(notice: t("multifactor_auths.strong_mfa_level_recommended")) if current_user.mfa_recommended_weak_level_enabled?
+
         redirect_back_or(url_after_create)
       else
         login_failure(status.failure_message)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -239,6 +239,14 @@ class User < ApplicationRecord
     rubygems.any?(&:mfa_recommended?)
   end
 
+  def mfa_recommended_not_yet_enabled?
+    mfa_recommended? && mfa_disabled?
+  end
+
+  def mfa_recommended_weak_level_enabled?
+    mfa_recommended? && mfa_ui_only?
+  end
+
   def otp_verified?(otp)
     otp = otp.to_s
     return true if verify_digit_otp(mfa_seed, otp)

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -297,6 +297,8 @@ de:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:
+    setup_recommended:
+    strong_mfa_level_recommended:
     new:
       title:
       scan_prompt:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -284,6 +284,8 @@ en:
     otp_code: OTP code
     require_mfa_disabled: Your multifactor authentication has been enabled. You have to disable it first.
     require_mfa_enabled: Your multifactor authentication has not been enabled. You have to enable it first.
+    setup_recommended: For protection of your account and your gems, we encourage you to set up multifactor authentication.
+    strong_mfa_level_recommended: For protection of your account and your gems, we encourage you to change your MFA level to "UI and gem signin" or "UI and API".
     new:
       title: Enabling multifactor auth
       scan_prompt: Please scan the qr-code with your authenticator app. If you cannot scan the code, add information below into your app manually.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -315,6 +315,8 @@ es:
       tienes que desactivarla.
     require_mfa_enabled: No se ha activado la autenticación de múltiples factores.
       Primero tienes que activarla.
+    setup_recommended:
+    strong_mfa_level_recommended:
     new:
       title: Activando autenticación de múltiples factores
       scan_prompt: Por favor escanea el código QR con tu aplicación de Autenticación.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -308,6 +308,8 @@ fr:
       devez d'abord la désactiver.
     require_mfa_enabled: Votre authentification multifacteur n'a pas été activée.
       Vous devez d'abord l'activer.
+    setup_recommended:
+    strong_mfa_level_recommended:
     new:
       title: Activer l'authentification multifacteur
       scan_prompt: Veuillez scanner le QR code avec votre app d'authentification.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -284,6 +284,8 @@ ja:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:
+    setup_recommended:
+    strong_mfa_level_recommended:
     new:
       title:
       scan_prompt:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -301,6 +301,8 @@ nl:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:
+    setup_recommended:
+    strong_mfa_level_recommended:
     new:
       title:
       scan_prompt:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -312,6 +312,8 @@ pt-BR:
     otp_code:
     require_mfa_disabled:
     require_mfa_enabled:
+    setup_recommended:
+    strong_mfa_level_recommended:
     new:
       title:
       scan_prompt:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -284,6 +284,8 @@ zh-CN:
     otp_code: OTP 码
     require_mfa_disabled: 你的多重要素验证已启用，请先停用。
     require_mfa_enabled: 你的多重要素验证已停用，请先启用。
+    setup_recommended:
+    strong_mfa_level_recommended:
     new:
       title: 启用多重要素验证
       scan_prompt: 请用你的验证装置扫描 QR-code。如果你没办法扫描，手动输入下面的资料。

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -285,6 +285,8 @@ zh-TW:
     otp_code: OTP 碼
     require_mfa_disabled: 你的多重要素驗證已啟用，請先停用。
     require_mfa_enabled: 你的多重要素驗證已停用，請先啟用。
+    setup_recommended:
+    strong_mfa_level_recommended:
     new:
       title: 啟用多重要素驗證
       scan_prompt: 請用你的驗證裝置掃描 QR-code。如果你沒辦法掃描，手動輸入下面的資料。

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -94,6 +94,73 @@ class SessionsControllerTest < ActionController::TestCase
       should "sign in the user" do
         assert @controller.request.env[:clearance].signed_in?
       end
+
+      context "when mfa is recommended" do
+        setup do
+          @user = User.new(email_confirmed: true, handle: "test")
+          @user.stubs(:mfa_recommended?).returns true
+        end
+
+        context "when mfa is disabled" do
+          setup do
+            User.expects(:authenticate).with("login", "pass").returns @user
+            post :create, params: { session: { who: "login", password: "pass" } }
+          end
+
+          should respond_with :redirect
+          should redirect_to("the mfa setup page") { new_multifactor_auth_path }
+
+          should "set notice flash" do
+            expected_notice = "For protection of your account and your gems, we encourage you to set up multifactor authentication."
+            assert_equal expected_notice, flash[:notice]
+          end
+        end
+
+        context "when mfa is enabled" do
+          setup do
+            @request.cookies[:mfa_feature] = "true"
+            @controller.session[:mfa_user] = @user.handle
+            User.expects(:find_by_slug).with(@user.handle).returns @user
+          end
+
+          context "on `ui_only` level" do
+            setup do
+              @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+              post :mfa_create, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
+            end
+
+            should respond_with :redirect
+            should redirect_to("the settings page") { edit_settings_path }
+
+            should "set notice flash" do
+              expected_notice = "For protection of your account and your gems, we encourage you to change your MFA level " \
+                                "to \"UI and gem signin\" or \"UI and API\"."
+
+              assert_equal expected_notice, flash[:notice]
+            end
+          end
+
+          context "on `ui_and_gem_signin` level" do
+            setup do
+              @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_gem_signin)
+              post :mfa_create, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
+            end
+
+            should respond_with :redirect
+            should redirect_to("the dashboard") { dashboard_path }
+          end
+
+          context "on `ui_and_api` level" do
+            setup do
+              @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+              post :mfa_create, params: { otp: ROTP::TOTP.new(@user.mfa_seed).now }
+            end
+
+            should respond_with :redirect
+            should redirect_to("the dashboard") { dashboard_path }
+          end
+        end
+      end
     end
 
     context "when login and password are incorrect" do

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class SignInTest < SystemTest
   setup do
-    create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: nil)
+    @user = create(:user, email: "nick@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD, handle: nil)
     @mfa_user = create(:user, email: "john@example.com", password: PasswordHelpers::SECURE_TEST_PASSWORD,
                   mfa_level: :ui_only, mfa_seed: "thisisonemfaseed",
                   mfa_recovery_codes: %w[0123456789ab ba9876543210])
@@ -117,6 +117,86 @@ class SignInTest < SystemTest
     click_button "Sign in"
 
     assert page.has_content? "Sign in"
+  end
+
+  test "signing in with mfa disabled with gem ownership that exceeds the recommended download threshold" do
+    rubygem = create(:rubygem)
+    Rubygem.any_instance.stubs(:downloads).returns(Rubygem::MFA_RECOMMENDED_THRESHOLD + 1)
+    create(:ownership, user: @user, rubygem: rubygem)
+
+    visit sign_in_path
+    fill_in "Email or Username", with: "nick@example.com"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Sign in"
+
+    expected_notice = "For protection of your account and your gems, we encourage you to set up multifactor authentication."
+    assert page.has_selector? "#flash_notice", text: expected_notice
+    assert_current_path(new_multifactor_auth_path)
+    assert page.has_content? "Sign out"
+  end
+
+  test "signing in with mfa enabled on `ui_only` with gem ownership that exceeds the recommended download threshold" do
+    rubygem = create(:rubygem)
+    Rubygem.any_instance.stubs(:downloads).returns(Rubygem::MFA_RECOMMENDED_THRESHOLD + 1)
+    create(:ownership, user: @mfa_user, rubygem: rubygem)
+
+    visit sign_in_path
+    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Sign in"
+
+    assert page.has_content? "Multifactor authentication"
+
+    fill_in "OTP code", with: "0123456789ab"
+    click_button "Sign in"
+
+    expected_notice = "For protection of your account and your gems, we encourage you to change your MFA level " \
+                      "to \"UI and gem signin\" or \"UI and API\"."
+    assert page.has_selector? "#flash_notice", text: expected_notice
+    assert_current_path(edit_settings_path)
+    assert page.has_content? "Sign out"
+  end
+
+  test "signing in with mfa enabled on `ui_and_gem_signin` with gem ownership that exceeds the recommended download threshold" do
+    @mfa_user.update!(mfa_level: :ui_and_gem_signin)
+    rubygem = create(:rubygem)
+    Rubygem.any_instance.stubs(:downloads).returns(Rubygem::MFA_RECOMMENDED_THRESHOLD + 1)
+    create(:ownership, user: @mfa_user, rubygem: rubygem)
+
+    visit sign_in_path
+    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Sign in"
+
+    assert page.has_content? "Multifactor authentication"
+
+    fill_in "OTP code", with: "0123456789ab"
+    click_button "Sign in"
+
+    assert_current_path(dashboard_path)
+    refute page.has_selector? "#flash_notice"
+    assert page.has_content? "Sign out"
+  end
+
+  test "signing in with mfa enabled on `ui_and_api` with gem ownership that exceeds the recommended download threshold" do
+    @mfa_user.update!(mfa_level: :ui_and_api)
+    rubygem = create(:rubygem)
+    Rubygem.any_instance.stubs(:downloads).returns(Rubygem::MFA_RECOMMENDED_THRESHOLD + 1)
+    create(:ownership, user: @mfa_user, rubygem: rubygem)
+
+    visit sign_in_path
+    fill_in "Email or Username", with: "john@example.com"
+    fill_in "Password", with: PasswordHelpers::SECURE_TEST_PASSWORD
+    click_button "Sign in"
+
+    assert page.has_content? "Multifactor authentication"
+
+    fill_in "OTP code", with: "0123456789ab"
+    click_button "Sign in"
+
+    assert_current_path(dashboard_path)
+    refute page.has_selector? "#flash_notice"
+    assert page.has_content? "Sign out"
   end
 
   test "siging in when user does not have handle" do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -355,47 +355,99 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
-    context "mfa_recommended?" do
-      should "be false when a user doesn't own a gem with more downloads than the recommended threshold" do
-        user = create(:user)
-        my_rubygem = create(:rubygem)
-        create(:ownership, user: user, rubygem: my_rubygem)
-        assert_equal [my_rubygem], user.rubygems
-
-        GemDownload.increment(
-          Rubygem::MFA_RECOMMENDED_THRESHOLD,
-          rubygem_id: my_rubygem.id
-        )
-
-        refute user.mfa_recommended?
+    context "recommend mfa" do
+      setup do
+        @rubygem = create(:rubygem)
+        create(:ownership, user: @user, rubygem: @rubygem)
+        assert_equal [@rubygem], @user.rubygems
       end
 
-      should "be true when user owns a gem with more downloads than the recommended threshold" do
-        user = create(:user)
-        my_rubygem = create(:rubygem)
-        create(:ownership, user: user, rubygem: my_rubygem)
-        assert_equal [my_rubygem], user.rubygems
+      context "when a user doesn't own a gem with more downloads than the recommended threshold" do
+        setup do
+          GemDownload.increment(
+            Rubygem::MFA_RECOMMENDED_THRESHOLD,
+            rubygem_id: @rubygem.id
+          )
+        end
 
-        GemDownload.increment(
-          Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
-          rubygem_id: my_rubygem.id
-        )
+        should "return false for mfa_recommended?" do
+          refute @user.mfa_recommended?
+        end
 
-        assert user.mfa_recommended?
+        should "return false for mfa_recommended_not_yet_enabled?" do
+          refute @user.mfa_recommended_not_yet_enabled?
+        end
+
+        should "return false for mfa_recommended_weak_level_enabled?" do
+          refute @user.mfa_recommended_weak_level_enabled?
+        end
       end
 
-      should "be false if a user already has a strong mfa level set" do
-        user = create(:user, mfa_level: "ui_and_api")
-        my_rubygem = create(:rubygem)
-        create(:ownership, user: user, rubygem: my_rubygem)
-        assert_equal [my_rubygem], user.rubygems
+      context "when mfa disabled user owns a gem with more downloads than the recommended threshold" do
+        setup do
+          GemDownload.increment(
+            Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
+            rubygem_id: @rubygem.id
+          )
+        end
 
-        GemDownload.increment(
-          Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
-          rubygem_id: my_rubygem.id
-        )
+        should "return true for mfa_recommended?" do
+          assert @user.mfa_recommended?
+        end
 
-        refute user.mfa_recommended?
+        should "return true for mfa_recommended_not_yet_enabled?" do
+          assert @user.mfa_recommended_not_yet_enabled?
+        end
+
+        should "return false for mfa_recommended_weak_level_enabled?" do
+          refute @user.mfa_recommended_weak_level_enabled?
+        end
+      end
+
+      context "when mfa `ui_only` user owns a gem with more downloads than the recommended threshold" do
+        setup do
+          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_only)
+
+          GemDownload.increment(
+            Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
+            rubygem_id: @rubygem.id
+          )
+        end
+
+        should "return true for mfa_recommended?" do
+          assert @user.mfa_recommended?
+        end
+
+        should "return false for mfa_recommended_not_yet_enabled?" do
+          refute @user.mfa_recommended_not_yet_enabled?
+        end
+
+        should "return true for mfa_recommended_weak_level_enabled?" do
+          assert @user.mfa_recommended_weak_level_enabled?
+        end
+      end
+
+      context "when strong user owns a gem with more downloads than the recommended threshold" do
+        setup do
+          @user.enable_mfa!(ROTP::Base32.random_base32, :ui_and_api)
+
+          GemDownload.increment(
+            Rubygem::MFA_RECOMMENDED_THRESHOLD + 1,
+            rubygem_id: @rubygem.id
+          )
+        end
+
+        should "return false for mfa_recommended?" do
+          refute @user.mfa_recommended?
+        end
+
+        should "return false for mfa_recommended_not_yet_enabled?" do
+          refute @user.mfa_recommended_not_yet_enabled?
+        end
+
+        should "return false for mfa_recommended_weak_level_enabled?" do
+          refute @user.mfa_recommended_weak_level_enabled?
+        end
       end
     end
   end


### PR DESCRIPTION
# ⚠️ Description is WIP
Resolves https://github.com/Shopify/ruby-conventions/issues/83

This is dependent on https://github.com/rubygems/rubygems.org/pull/2987/files being merged. 

__

This PR contributes to Phase 2 of the MFA RFC. More specifically, after login, it redirects users to setup or change their MFA setting if they are recommended to (based on a gem threshold). Users can disregard the warning at this stage.

### 1. User is not under `mfa_recommended?`
no change, redirects to user dashboard.

### 2. User is under `mfa_recommended?` and has mfa enabled on the `ui_and_gem_signin` and `ui_and_api` level
no change, redirects to user dashboard.

### 3. User has mfa disabled and is under `mfa_recommended?`
Redirect to mfa setup page and show the following banner
```
For protection of your account and your gems, we encourage you to set up multifactor authentication.
```
<details>
  <summary>Video</summary>
  
 

https://user-images.githubusercontent.com/42748004/158090103-157f404e-8af3-4dd2-a7a4-2856f17d9c77.mov



</details>

### 4. User has mfa enabled under `ui_only` and is under `mfa_recommended?`
Redirect to user settings and show the following banner
```
For protection of your account and your gems, we encourage you to change your MFA level to "UI and gem signin" or "UI and API".
```

<details>
  <summary>Video</summary>
  

https://user-images.githubusercontent.com/42748004/158089913-7b773efa-e480-4cf7-be8a-cb67fe6dd645.mov


 
</details>