### PR TITLE
Mailer: Email to announce MFA Phase 2 rollout and blog post on Launch Day

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -68,6 +68,13 @@ class Mailer < ApplicationMailer
       subject: "Please consider enabling multifactor authentication for your account"
   end
 
+  def mfa_recommendation_announcement(user_id)
+    @user = User.find(user_id)
+
+    mail to: @user.email,
+      subject: "Official Recommendation: Enable MFA on your RubyGems account"
+  end
+
   def gem_yanked(yanked_by_user_id, version_id, notified_user_id)
     @version        = Version.find(version_id)
     notified_user   = User.find(notified_user_id)

--- a/app/views/mailer/mfa_recommendation_announcement.html.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.html.erb
@@ -1,0 +1,128 @@
+<% @title = "Enable multi-factor authentication (MFA) on your RubyGems account" %>
+<% @sub_title = "👋 Hi #{@user.handle}" %>
+
+<!-- Body -->
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#ffffff">
+  <tr>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+    <td>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px;">
+        <p>
+          Today, we've announced our security-focused ambitions to the community. 
+          Attacks on the software supply chain are increasing and the second most common attack is account takeovers.
+        </p>
+        <br/>
+
+        <p>
+          On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled.
+          Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. 
+          This recommendation will be repeated by the gem client. 
+        </p>
+        <br/>
+
+        <% if @user.mfa_disabled? %> 
+          <p>
+            While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers. 
+            <b>Please enable multi-factor authentication on your RubyGems account 🙏.</b>
+          </p>
+          <br/>
+
+          <p>
+            We recommend setting the 
+            <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels" target="_blank">MFA level</a>
+            to <b><i>UI and API</i></b>. However, <b><i>UI and gem signin</i></b> is acceptable too.
+          </p>
+          <br />
+        <% elsif @user.mfa_ui_only? %>
+          <p>
+            While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers.
+            Fortunately, you've already taken the first step! But, there's opportunity to improve.
+            <b>Please upgrade your RubyGems account to a stronger MFA level 🙏.</b>
+          </p>
+          <br/>
+
+          <p>
+            We recommend setting the 
+            <a href="https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels" target="_blank">MFA level</a>
+            to <b><i>UI and API</i></b>. However, <b><i>UI and gem signin</i></b> is acceptable too.
+          </p>
+          <br />
+        <% else %>
+          <p>
+            While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers by enabling MFA on their accounts. 
+            Fortunately, you've already done that. Kudos to you 🥳 🙌!
+          </p>
+          <br/>
+        <% end %>
+
+        <p>
+          For more information, check out our <a href="#" target="_blank">announcement</a>.
+        </p>
+        <br/>
+        <br/>
+       
+        <p align="center">❤️ 💪 💎 💪 ❤️</p>
+        <p align="center"> Thank you for making the RubyGems ecosystem more secure.</p>
+        <p align="center">❤️ 💪 💎 💪 ❤️</p>
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="30" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <% if @user.mfa_disabled? || @user.mfa_ui_only? %> 
+
+        <!-- Button -->
+        <table width="100%" border="0" cellspacing="0" cellpadding="0">
+          <tr>
+            <td align="center">
+              <table width="210" border="0" cellspacing="0" cellpadding="0">
+                <tr>
+                  <td align="center" bgcolor="#e9573f">
+                    <table border="0" cellspacing="0" cellpadding="0">
+                      <tr>
+                        <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15">
+                          <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">
+                            <tr>
+                              <td height="50" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td>
+                            </tr>
+                          </table>
+                        </td>
+                        <td bgcolor="#e9573f">
+                          <div class="text-btn" style="color:#ffffff; font-family:Arial, sans-serif; min-width:auto !important; font-size:16px; line-height:20px; text-align:center">
+                            <a href=<%= new_multifactor_auth_url %> target="_blank" class="link-white" style="color:#ffffff; text-decoration:none">
+                              <span class="link-white" style="color:#ffffff; text-decoration:none">
+                                <%= "ENABLE MFA" if @user.mfa_disabled? %>
+                                <%= "STRENGTHEN MFA LEVEL" if @user.mfa_ui_only? %>
+                              </span>
+                            </a>
+                          </div>
+                        </td>
+                        <td class="img" style="font-size:0pt; line-height:0pt; text-align:left" width="15"></td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+        <!-- END Button -->
+      <% end %>
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="40" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <div class="h3-1-center" style="color:#1e1e1e; font-family:Georgia, serif; min-width:auto !important; font-size:20px; line-height:26px; text-align:center">
+        Check our guides for more details on <%= link_to("setting up multi-factor authentication (MFA)", "https://guides.rubygems.org/setting-up-multifactor-authentication/") %>  and  <%= link_to("using multi-factor authentication (MFA) with command line", "https://guides.rubygems.org/using-mfa-in-command-line/") %>.
+      </div>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+      <table width="100%" border="0" cellspacing="0" cellpadding="0" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%"><tr><td height="35" class="spacer" style="font-size:0pt; line-height:0pt; text-align:center; width:100%; min-width:100%">&nbsp;</td></tr></table>
+
+    </td>
+    <td class="content-spacing" style="font-size:0pt; line-height:0pt; text-align:left" width="20"></td>
+  </tr>
+</table>
+<!-- END Body -->

--- a/app/views/mailer/mfa_recommendation_announcement.html.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.html.erb
@@ -60,7 +60,7 @@
         <% end %>
 
         <p>
-          For more information, check out our <a href="#" target="_blank">announcement</a>.
+          For more information, check out our <a href="https://blog.rubygems.org/2022/06/13/making-packages-more-secure.html" target="_blank">announcement</a>.
         </p>
         <br/>
         <br/>

--- a/app/views/mailer/mfa_recommendation_announcement.text.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.text.erb
@@ -1,0 +1,24 @@
+👋 Hi <%= @user.handle %>,
+
+Today, we've announced our security-focused ambitions to the community. Attacks on the software supply chain are increasing and the second most common attack is account takeovers.
+
+On August 15, 2022, we will begin requiring maintainers of packages with more than 180 million downloads to have multi-factor authentication (MFA) enabled. Furthermore, we are officially recommending that maintainers of packages with more than 165 million downloads enable MFA. This recommendation will be repeated by the gem client. 
+
+<% if @user.mfa_disabled? %> 
+While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers. 
+Please enable multi-factor authentication on your RubyGems account 🙏.
+
+We recommend setting the MFA level to "UI and API". However, "UI and gem signin" is acceptable too (https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels).
+<% elsif @user.mfa_ui_only? %>
+While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers. Fortunately, you've already taken the first step! But, there's opportunity to improve.
+Please upgrade your RubyGems account to a stronger MFA level 🙏.
+
+We recommend setting the MFA level to "UI and API". However, "UI and gem signin" is acceptable too (https://guides.rubygems.org/setting-up-multifactor-authentication/#authentication-levels).
+<% else %>
+While this policy impacts specific RubyGems users, everyone can do their part to help combat account takeovers by enabling MFA on their accounts. 
+Fortunately, you've already done that. Kudos to you 🥳 🙌!
+<% end %>
+
+For more information, check out our announcement (#link-to-blog-post-tbd).
+
+❤️ Thank you for making the RubyGems ecosystem more secure

--- a/app/views/mailer/mfa_recommendation_announcement.text.erb
+++ b/app/views/mailer/mfa_recommendation_announcement.text.erb
@@ -19,6 +19,6 @@ While this policy impacts specific RubyGems users, everyone can do their part to
 Fortunately, you've already done that. Kudos to you 🥳 🙌!
 <% end %>
 
-For more information, check out our announcement (#link-to-blog-post-tbd).
+For more information, check out our announcement (https://blog.rubygems.org/2022/06/13/making-packages-more-secure.html).
 
 ❤️ Thank you for making the RubyGems ecosystem more secure

--- a/lib/tasks/mfa_policy.rake
+++ b/lib/tasks/mfa_policy.rake
@@ -1,0 +1,32 @@
+require "resolv"
+
+def mx_exists?(email)
+  domain = email.split("@").last
+  mx_resolver = Resolv::DNS.new
+  mx_resolver.timeouts = 10
+
+  return false if mx_resolver.getresources(domain, Resolv::DNS::Resource::IN::MX).empty?
+  true
+rescue StandardError => e
+  puts "Error during processing: #{$ERROR_INFO}"
+  puts "Backtrace:\n\t#{e.backtrace.join("\n\t")}"
+  false
+end
+
+namespace :mfa_policy do
+  # To be sent on launch day (June 13, 2022)
+  # rake mfa_policy:announce_recommendation
+  desc "Send email notification to all users about MFA Phase 2 rollout (MFA Recommendation for popular gems)"
+  task announce_recommendation: :environment do
+    users = User.all
+    total_users = users.count
+    puts "Sending #{total_users} MFA announcement email"
+
+    i = 0
+    users.find_each do |user|
+      Mailer.delay.mfa_recommendation_announcement(user.id) if mx_exists?(user.email)
+      i += 1
+      print format("\r%.2f%% (%d/%d) complete", i.to_f / total * 100.0, i, total)
+    end
+  end
+end

--- a/test/mailers/previews/mailer_preview.rb
+++ b/test/mailers/previews/mailer_preview.rb
@@ -37,6 +37,10 @@ class MailerPreview < ActionMailer::Preview
     Mailer.mfa_notification(User.last.id)
   end
 
+  def mfa_recommendation_announcement
+    Mailer.mfa_recommendation_announcement(User.last.id)
+  end
+
   def gem_yanked
     ownership = Ownership.where.not(user: nil).last
     Mailer.gem_yanked(ownership.user.id, ownership.rubygem.versions.last.id, ownership.user.id)


### PR DESCRIPTION
## 🤷‍♀️ What problem are you solving?
Contributes to https://github.com/Shopify/ruby-conventions/issues/88

On Launch Day (June 13, 2022), RubyGems will be announcing the rollout of an MFA policy. To raise awareness about this policy which will be announced in a [blog post](https://github.com/rubygems/rubygems.github.io/pull/110), we plan on emailing all RubyGems users.


## 📋 How will you solve this?
🔹 **Create a mailer** (0d935233c9891ec989a2d8c2acc739b5174119c3)
- Adds a mailer action `mfa_recommendation_announcement` and a mailer view in both `HTML` and `plain text` formats

🔹 **Set up mailer preview** (c1940df0cd8d8cab3a2b8f5b9e574bea706d0156)
- So we can more easily tophat and preview the email in both HTML and plain text, I've set up a mailer preview

🔹 **Add rake task for delivering the email** (d5e42d3495a4e297a74fad3e725772b151bb5126)
- This will be the task that the RubyGems Team will run on Launch Day to send out the email
- I've followed similar logging that they've done in a previous mailer

## 🤔 Review feedback
⚠️ 📆 I will be upstreaming this to `rubygems/rubygems.org` by 5pm EST today. If you don't get a chance to review here, I'd still love your feedback in the ~ official PR ~.

I'm looking for review feedback on the following items:

**1️⃣ Location of rake task**
 * There's [an existing rake task](https://github.com/rubygems/rubygems.org/blob/master/lib/tasks/mfa_notification.rake) called `mfa_notification`, but I chose to create a new one called `mfa_policy`
 * My rationale is that we'll have other mailers that we'll need to set up related to the mfa policy. So it felt fitting to create a namespace for the mfa policy specifically. But! I'm open to feedback and cool with keeping everything under the `mfa_notification` namespace

**2️⃣ Logging invalid emails**
  * Would it be beneficial to log which accounts have invalid emails and did not receive the announcement?
  * It appears the previous `mfa_notification:send` rake task that RubyGems had previously set up _did not_ log it. So I'm currently following their pattern.

**3️⃣ Plain text emails**
  * It appears there isn't a consistent practice of adding a plain text format with mailers in this repo
  * I've decided to add a plain text email anyway
  * Any strong opinions about removing the plain text format?

**4️⃣ Email copy**
  * I'd love feedback on the email subject line & copy. I'm [soliciting feedback](https://github.com/rubygems/rubygems.org/issues/3050#issuecomment-1148196221) from Aditya and Josef too. But as we await their thoughts, we can continue adjusting as needed. I'll update the issue for A+J accordingly.

## 🎩 Tophat instructions

**📧 To preview the email:**
- Once you have the app running (`rails s`)
- You can navigate to (`http://localhost:3000/rails/mailers`) to review the list of all mailers available for preview
  - To view this mailer, click on the link titled: `mfa_recommendation_announcement`
- The mailer for this PR is located at `http://localhost:3000/rails/mailers/mailer/mfa_recommendation_announcement`

**👤 To change the user:**
- The user is configured on the mailer preview based on `MailerPreview#mfa_recommendation_announcement`. 
  - To change the user to verify various MFA states, you can either replace `User.last.id` with a different user (e.g. `User.first`)
  - Alternatively, you can adjust the MFA status on your last user

### 👀 Email versions
**🚫 Email for users with MFA disabled**
(Click image to enlarge)
<p align="center">
  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/172514024-4f39ab20-30ac-46bb-b6fa-b905d3bc019e.png" alt="Email for users with MFA disabled - HTML format" width=250 />
  </kbd>

  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/172514023-fd4a9025-8c87-438c-b7dc-b56e96d22346.png" alt="Email for users with MFA disabled - Plain text format" width=250 />
  </kbd>
</p>

**🤞 Email for users with MFA enabled (`ui_only`) -- weak MFA**
(Click image to enlarge)
<p align="center">
  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/172514015-a6b6a196-4478-4e94-8de6-f28dc580f6a0.png" alt="Email for users with MFA enabled set to ui_only - Plain text format" width=250 />
  </kbd>

  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/172514013-4c868f06-8f52-4609-91c6-314379f94888.png" alt="Email for users with MFA enabled set to ui_only - HTML format" width=250 />
  </kbd>
</p>

**Email for users with MFA enabled (`ui_and_api` or `ui_and_gem_signin`**
(Click image to enlarge)
<p align="center">
  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/172513999-273feb64-cb6e-4581-bafe-0264074d7e26.png" alt="Email for users with MFA enabled - Plain text format" width=250 />
  </kbd>

  <kbd>
    <img src="https://user-images.githubusercontent.com/4270287/172513996-e61e36fa-0f87-4cb6-b79a-fbc6e084ced6.png" alt="Email for users with MFA enabled - HTML format" width=250 />
  </kbd>
</p>