### PR TITLE
Generate OTP after successful webauthn verification

### DIFF
--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -22,9 +22,8 @@ class WebauthnVerificationsController < ApplicationController
     )
 
     user_webauthn_credential.update!(sign_count: webauthn_credential.sign_count)
-    # TODO: generate webauthn verification otp
-    @webauthn_otp = 12_345
 
+    @verification.generate_otp
     @verification.expire_path_token
 
     render :success

--- a/app/models/webauthn_verification.rb
+++ b/app/models/webauthn_verification.rb
@@ -13,4 +13,10 @@ class WebauthnVerification < ApplicationRecord
   def path_token_expired?
     path_token_expires_at < Time.now.utc
   end
+
+  def generate_otp
+    self.otp = SecureRandom.base58(20)
+    self.otp_expires_at = 2.minutes.from_now
+    save!
+  end
 end

--- a/app/views/webauthn_verifications/success.html.erb
+++ b/app/views/webauthn_verifications/success.html.erb
@@ -3,5 +3,5 @@
 <div class="t-body">
   <h2>Verified as <%= @user.name %></h2>
   <p>Please enter this code in the command line</p>
-  <pre><%= @webauthn_otp %></pre>
+  <pre><%= @verification.otp %></pre>
 </div>

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -64,7 +64,8 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       @user = create(:user)
       @webauthn_credential = create(:webauthn_credential, user: @user)
       travel_to Time.utc(2023, 1, 1, 0, 0, 0) do
-        @token = create(:webauthn_verification, user: @user, otp: nil, otp_expires_at: nil).path_token
+        @verification = create(:webauthn_verification, user: @user, otp: nil, otp_expires_at: nil)
+        @token = @verification.path_token
         get :prompt, params: { webauthn_token: @token }
       end
     end
@@ -94,7 +95,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
             format: :html
           )
         end
-        @user.webauthn_verification.reload
+        @verification.reload
       end
 
       should respond_with :success
@@ -104,9 +105,8 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       end
 
       should "render success with OTP" do
-        otp = @user.webauthn_verification.reload.otp
-        assert_not_nil otp
-        assert page.has_content?(otp)
+        assert_not_nil @verification.otp
+        assert page.has_content?(@verification.otp)
       end
 
       should "expire the path token by setting its expiry to 1 second prior" do
@@ -126,7 +126,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
             format: :html
           )
         end
-        @user.webauthn_verification.reload
+        @verification.reload
       end
 
       should respond_with :unauthorized
@@ -140,8 +140,8 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       end
 
       should "not generate OTP" do
-        assert_nil @user.webauthn_verification.otp
-        assert_nil @user.webauthn_verification.otp_expires_at
+        assert_nil @verification.otp
+        assert_nil @verification.otp_expires_at
       end
     end
 
@@ -169,6 +169,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
             format: :html
           )
         end
+        @verification.reload
       end
 
       should respond_with :unauthorized
@@ -177,8 +178,8 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       end
 
       should "not generate OTP" do
-        assert_nil @user.webauthn_verification.otp
-        assert_nil @user.webauthn_verification.otp_expires_at
+        assert_nil @verification.otp
+        assert_nil @verification.otp_expires_at
       end
     end
 

--- a/test/unit/webauthn_verification_test.rb
+++ b/test/unit/webauthn_verification_test.rb
@@ -50,4 +50,23 @@ class WebauthnVerificationTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "#generate_otp" do
+    setup do
+      @webauthn_verification = create(:webauthn_verification, otp: nil, otp_expires_at: nil)
+      @generated_time = Time.utc(2023, 1, 1, 0, 0, 0)
+      travel_to @generated_time do
+        @webauthn_verification.generate_otp
+      end
+      @webauthn_verification.reload
+    end
+
+    should "create a token that is 20 characters long" do
+      assert_equal 20, @webauthn_verification.otp.length
+    end
+
+    should "set a 2 minute expiry" do
+      assert_equal @generated_time + 2.minutes, @webauthn_verification.otp_expires_at
+    end
+  end
 end


### PR DESCRIPTION
Blocked by: https://github.com/rubygems/rubygems.org/pull/3334

## What problem are you solving?

Part of https://github.com/rubygems/rubygems.org/pull/3298

After successful verification of Webauthn credentials, an OTP needs generated, and shown to the user to paste into the CLI

## What approach did you choose and why?
- Added a generate otp method on WebauthnVerification model
- After webauthn credentials are verified, generate the otp as `SecureRandom.base58(20)` with 2 minute expiry.
<img width="1053" alt="Screenshot 2023-01-13 at 11 55 11 AM" src="https://user-images.githubusercontent.com/42748004/212375546-dbe58ffa-8ca9-4c15-8ec0-178ae85533b9.png">

## What should reviewers focus on?
- is `SecureRandom.base58(20)` fine for the otp and 2 minutes as the expiry?