### PR TITLE
Refine WebAuthn Verification success page

### DIFF
--- a/app/assets/javascripts/webauthn.js
+++ b/app/assets/javascripts/webauthn.js
@@ -28,11 +28,18 @@
     } else {
       response.text().then(function (html) {
         document.body.innerHTML = html;
+        handleClipboard();
       }).catch(function (error) {
         setError(submit, responseError, error);
       });
     }
   };
+
+  var handleClipboard = function() {
+    var clipboard = new ClipboardJS('.clipboard--otp__icon');
+
+    clipboard.on('success', function(e) { e.clearSelection() });
+  }
 
   var credentialsToBase64 = function(credentials) {
     return {

--- a/app/assets/javascripts/webauthn.js
+++ b/app/assets/javascripts/webauthn.js
@@ -10,12 +10,24 @@
     error.text(message);
   };
 
-  var handleResponse = function(submit, responseError, response) {
+  var handleJsonResponse = function(submit, responseError, response) {
     if (response.redirected) {
       window.location.href = response.url;
     } else {
       response.json().then(function (json) {
         setError(submit, responseError, json.message);
+      }).catch(function (error) {
+        setError(submit, responseError, error);
+      });
+    }
+  };
+
+  var handleHtmlResponse = function(submit, responseError, response) {
+    if (response.redirected) {
+      window.location.href = response.url;
+    } else {
+      response.text().then(function (html) {
+        document.body.innerHTML = html;
       }).catch(function (error) {
         setError(submit, responseError, error);
       });
@@ -83,7 +95,7 @@
           })
         });
       }).then(function (response) {
-        handleResponse(credentialSubmit, credentialError, response);
+        handleJsonResponse(credentialSubmit, credentialError, response);
       }).catch(function (error) {
         setError(credentialSubmit, credentialError, error);
       });
@@ -104,7 +116,7 @@
       navigator.credentials.get({
         publicKey: options
       }).then(function (credentials) {
-        return fetch(form.action + ".json", {
+        return fetch(form.action + ".html", {
           method: "POST",
           credentials: "same-origin",
           headers: {
@@ -116,7 +128,7 @@
           })
         });
       }).then(function (response) {
-        handleResponse(sessionSubmit, sessionError, response);
+        handleHtmlResponse(sessionSubmit, sessionError, response);
       }).catch(function (error) {
         setError(sessionSubmit, sessionError, error);
       });

--- a/app/assets/stylesheets/modules/clipboard.css
+++ b/app/assets/stylesheets/modules/clipboard.css
@@ -1,0 +1,33 @@
+.clipboard--otp {
+  margin: 3em 0;
+  max-width: 25em;
+  border: 1px solid #141c22;
+  border-radius: 0.5em;
+  height: 3em;
+  display: grid;
+  grid-template-columns: auto 3em;
+  overflow: hidden;
+}
+
+.clipboard--otp__text {
+  padding: 0.8em;
+  font-family: "courier", monospace;
+  font-size: 1em;
+  color: #141c22;
+  font-weight: bold;
+  border: none;
+}
+
+.clipboard--otp__icon {
+  width: 3em;
+  background-color: #141c22;
+  text-align: center;
+  line-height: 3em;
+  color: #ffffff;
+  font-family: "icomoon";
+  cursor: pointer;
+}
+
+.clipboard--otp__icon:hover {
+  background-color: #9A9A9A;
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -24,10 +24,10 @@ class SessionsController < Clearance::SessionsController
     @challenge = session.dig(:webauthn_authentication, "challenge")
 
     if params[:credentials].blank?
-      login_failure("Credentials required")
+      webauthn_verification_failure("Credentials required")
       return
     elsif !session_active?
-      login_failure(t("multifactor_auths.session_expired"))
+      webauthn_verification_failure(t("multifactor_auths.session_expired"))
       return
     end
 
@@ -47,7 +47,7 @@ class SessionsController < Clearance::SessionsController
 
     do_login
   rescue WebAuthn::Error => e
-    login_failure(e.message)
+    webauthn_verification_failure(e.message)
   ensure
     session.delete(:webauthn_authentication)
     session.delete(:mfa_expires_at)
@@ -105,16 +105,13 @@ class SessionsController < Clearance::SessionsController
 
   def login_failure(message)
     StatsD.increment "login.failure"
+    flash.now.notice = message
+    render "sessions/new", status: :unauthorized
+  end
 
-    respond_to do |format|
-      format.json do
-        render json: { message: message }, status: :unauthorized
-      end
-      format.html do
-        flash.now.notice = message
-        render template: "sessions/new", status: :unauthorized
-      end
-    end
+  def webauthn_verification_failure(message = nil)
+    flash.now.notice = message
+    render "sessions/prompt", status: :unauthorized
   end
 
   def session_params

--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -21,13 +21,15 @@ class WebauthnVerificationsController < ApplicationController
 
     user_webauthn_credential.update!(sign_count: webauthn_credential.sign_count)
     # TODO: generate webauthn verification otp
+    @webauthn_otp = 12_345
 
-    # TODO: render html with webauthn verification otp instead of json
-    render json: { message: "success" }
+    render :success
   rescue WebAuthn::Error => e
-    render json: { message: e.message }, status: :unauthorized
+    flash.now.notice = e.message
+    render :prompt, status: :unauthorized
   rescue ActionController::ParameterMissing
-    render json: { message: "Credentials required" }, status: :unauthorized
+    flash.now.notice = "Credentials required"
+    render :prompt, status: :unauthorized
   ensure
     session.delete(:webauthn_authentication)
   end

--- a/app/views/webauthn_verifications/success.html.erb
+++ b/app/views/webauthn_verifications/success.html.erb
@@ -1,0 +1,7 @@
+<% @title = "Verify with Security Device" %>
+
+<div class="t-body">
+  <h2>Verified as <%= @user.name %></h2>
+  <p>Please enter this code in the command line</p>
+  <pre><%= @webauthn_otp %></pre>
+</div>

--- a/app/views/webauthn_verifications/success.html.erb
+++ b/app/views/webauthn_verifications/success.html.erb
@@ -3,5 +3,8 @@
 <div class="t-body">
   <h2><%= t(".authenticated_as") %> <%= @user.name %></h2>
   <p><%= t(".enter_otp") %></p>
-  <pre><%= @webauthn_otp %></pre>
+  <div class="clipboard--otp">
+    <input type="text" class="clipboard--otp__text" id="webauthn_otp" value="<%= @webauthn_otp %>" readonly="readonly">
+    <span class="clipboard--otp__icon" data-clipboard-target="#webauthn_otp">=</span>
+  </div>
 </div>

--- a/app/views/webauthn_verifications/success.html.erb
+++ b/app/views/webauthn_verifications/success.html.erb
@@ -1,7 +1,7 @@
-<% @title = "Verify with Security Device" %>
+<% @title = t(".title") %>
 
 <div class="t-body">
-  <h2>Verified as <%= @user.name %></h2>
-  <p>Please enter this code in the command line</p>
+  <h2><%= t(".authenticated_as") %> <%= @user.name %></h2>
+  <p><%= t(".enter_otp") %></p>
   <pre><%= @webauthn_otp %></pre>
 </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -355,6 +355,10 @@ de:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    success:
+      title:
+      authenticated_as:
+      enter_otp:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -344,6 +344,10 @@ en:
       authenticating_as: Authenticating as
       authenticate: Authenticate
       no_webauthn_devices: You don't have any security devices enabled
+    success:
+      title: Authenticate with Security Device
+      authenticated_as: Authenticated as
+      enter_otp: Please paste this one-time password into your command line.
   owners:
     confirm:
       confirmed_email: You were added as an owner to %{gem} gem

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -377,6 +377,10 @@ es:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    success:
+      title:
+      authenticated_as:
+      enter_otp:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -380,6 +380,10 @@ fr:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    success:
+      title:
+      authenticated_as:
+      enter_otp:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -342,6 +342,10 @@ ja:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    success:
+      title:
+      authenticated_as:
+      enter_otp:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -359,6 +359,10 @@ nl:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    success:
+      title:
+      authenticated_as:
+      enter_otp:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -370,6 +370,10 @@ pt-BR:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    success:
+      title:
+      authenticated_as:
+      enter_otp:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -342,6 +342,10 @@ zh-CN:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    success:
+      title:
+      authenticated_as:
+      enter_otp:
   owners:
     confirm:
       confirmed_email:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -343,6 +343,10 @@ zh-TW:
       authenticating_as:
       authenticate:
       no_webauthn_devices:
+    success:
+      title:
+      authenticated_as:
+      enter_otp:
   owners:
     confirm:
       confirmed_email:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,8 +185,7 @@ Rails.application.routes.draw do
     resources :webauthn_credentials, only: :destroy
     resource :webauthn_verification, only: [] do
       get ':webauthn_token', to: 'webauthn_verifications#prompt', as: ''
-      # TODO: add html as a valid format
-      post ':webauthn_token', to: 'webauthn_verifications#authenticate', as: :authenticate, constraints: { format: /json/ }
+      post ':webauthn_token', to: 'webauthn_verifications#authenticate', as: :authenticate
     end
 
     ################################################################################

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,6 +202,7 @@ Rails.application.routes.draw do
 
     resource :session, only: %i[create destroy] do
       post 'mfa_create', to: 'sessions#mfa_create', as: :mfa_create
+      post 'webauthn_create', to: 'sessions#webauthn_create', as: :webauthn_create
       get 'verify', to: 'sessions#verify', as: :verify
       post 'authenticate', to: 'sessions#authenticate', as: :authenticate
     end
@@ -220,11 +221,8 @@ Rails.application.routes.draw do
 
   ################################################################################
   # UI API
-  scope constraints: { format: :json }, defaults: { format: :json } do
-    resource :session, only: [] do
-      post 'webauthn_create', to: 'sessions#webauthn_create', as: :webauthn_create
-    end
 
+  scope constraints: { format: :json }, defaults: { format: :json } do
     resources :webauthn_credentials, only: :create do
       post :callback, on: :collection
     end

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -428,7 +428,7 @@ class SessionsControllerTest < ActionController::TestCase
                 challenge: @challenge
               )
           },
-          format: :json
+          format: :html
         )
       end
 
@@ -449,11 +449,14 @@ class SessionsControllerTest < ActionController::TestCase
         )
         post(
           :webauthn_create,
-          format: :json
+          format: :html
         )
       end
 
       should respond_with :unauthorized
+      should "set flash notice" do
+        assert_equal "Credentials required", flash[:notice]
+      end
     end
 
     context "when providing wrong credentials" do
@@ -481,11 +484,14 @@ class SessionsControllerTest < ActionController::TestCase
                 challenge: @wrong_challenge
               )
           },
-          format: :json
+          format: :html
         )
       end
 
       should respond_with :unauthorized
+      should "set flash notice" do
+        assert_equal "WebAuthn::ChallengeVerificationError", flash[:notice]
+      end
     end
 
     context "when providing credentials but the session expired" do
@@ -514,7 +520,7 @@ class SessionsControllerTest < ActionController::TestCase
                 challenge: @challenge
               )
           },
-          format: :json
+          format: :html
         )
       end
 
@@ -526,6 +532,10 @@ class SessionsControllerTest < ActionController::TestCase
 
       should "not sign in the user" do
         refute_predicate @controller.request.env[:clearance], :signed_in?
+      end
+
+      should "set flash notice" do
+        assert_equal "Your login page session has expired.", flash[:notice]
       end
     end
   end

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -97,13 +97,14 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
               ),
             webauthn_token: @token
           },
-          format: :json
+          format: :html
         )
       end
 
       should respond_with :success
-      should "return success message" do
-        assert_equal "success", JSON.parse(response.body)["message"]
+      should "render success with OTP" do
+        # TODO: check with webauthn verification otp
+        assert page.has_content?("12345")
       end
     end
 
@@ -114,13 +115,13 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
           params: {
             webauthn_token: @token
           },
-          format: :json
+          format: :html
         )
       end
 
       should respond_with :unauthorized
-      should "return error message" do
-        assert_equal "Credentials required", JSON.parse(response.body)["message"]
+      should "set flash notice" do
+        assert_equal "Credentials required", flash[:notice]
       end
     end
 
@@ -144,13 +145,13 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
               ),
             webauthn_token: @token
           },
-          format: :json
+          format: :html
         )
       end
 
       should respond_with :unauthorized
-      should "return error message" do
-        assert_equal "WebAuthn::ChallengeVerificationError", JSON.parse(response.body)["message"]
+      should "set flash notice" do
+        assert_equal "WebAuthn::ChallengeVerificationError", flash[:notice]
       end
     end
 
@@ -175,7 +176,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
               ),
             webauthn_token: @wrong_webuthn_token
           },
-          format: :json
+          format: :html
         )
       end
 

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -104,7 +104,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       should respond_with :success
       should "render success with OTP" do
         # TODO: check with webauthn verification otp
-        assert page.has_content?("12345")
+        assert page.has_selector?("input[value='12345']")
       end
     end
 


### PR DESCRIPTION
Blocked by: https://github.com/rubygems/rubygems.org/pull/3334

## What problem are you solving?

Part of https://github.com/rubygems/rubygems.org/pull/3298

After successful verification of Webauthn credentials, an OTP needs to be shown to the user to paste into the CLI. This PR refines that view by:

- Adding the translations
- Adding a clipboard to copy the code. I added a hover style to make it more visible when someone clicks the clipboard.


## What approach did you choose and why?
Based the styles off of the [copy gemfile code](https://github.com/Shopify/rubygems.org/blob/master/app/views/rubygems/_aside.html.erb#L25-L30) in the show rubygems page.

<img width="157" alt="Screenshot 2023-01-17 at 2 29 21 PM" src="https://user-images.githubusercontent.com/42748004/212994163-fe74a14e-2709-47af-9aba-8ed8567439b3.png">

I wanted the clipboard to be a bit more lightweight so I omitted the "copy to clipboard" on hover and just changed the background colour on the icon (see vid below). If we deem it's necessary, I can add it back in.

![](https://user-images.githubusercontent.com/42748004/212742641-061de7e4-df32-4af6-ad57-857b1098720c.png)

## What should reviewers focus on?
- Did I follow the proper CSS/JS conventions?
- Should the clipboard react differently on hover / on click?

## Testing
1. Enable a webauthn device for the user
2. Create a webauthn verification link by running `RUBYGEMS_HOST=http://localhost:3000 ruby -Ilib bin/gem signin` on this https://github.com/rubygems/rubygems/pull/6179 
3. Access the link and verify your webauthn credential
4. You should see the success page that you can copy the OTP by clicking the clipboard

https://user-images.githubusercontent.com/42748004/212996695-6f852d5d-64ae-477b-89c7-041ae1706376.mov