### PR TITLE
Generate webauthn verification otp

### DIFF
--- a/app/controllers/webauthn_verifications_controller.rb
+++ b/app/controllers/webauthn_verifications_controller.rb
@@ -22,8 +22,8 @@ class WebauthnVerificationsController < ApplicationController
     )
 
     user_webauthn_credential.update!(sign_count: webauthn_credential.sign_count)
-    # TODO: generate webauthn verification otp
 
+    @verification.generate_otp
     @verification.expire_path_token
 
     # TODO: render html with webauthn verification otp instead of json

--- a/app/models/webauthn_verification.rb
+++ b/app/models/webauthn_verification.rb
@@ -13,4 +13,10 @@ class WebauthnVerification < ApplicationRecord
   def path_token_expired?
     path_token_expires_at < Time.now.utc
   end
+
+  def generate_otp
+    self.otp = SecureRandom.base58(20)
+    self.otp_expires_at = 2.minutes.from_now
+    save!
+  end
 end

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -64,7 +64,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       @user = create(:user)
       @webauthn_credential = create(:webauthn_credential, user: @user)
       travel_to Time.utc(2023, 1, 1, 0, 0, 0) do
-        @token = create(:webauthn_verification, user: @user).path_token
+        @token = create(:webauthn_verification, user: @user, otp: nil, otp_expires_at: nil).path_token
         get :prompt, params: { webauthn_token: @token }
       end
     end
@@ -79,7 +79,8 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
           webauthn_credential: @webauthn_credential,
           client: @client
         )
-        travel_to Time.utc(2023, 1, 1, 0, 0, 3) do
+        @generated_time = Time.utc(2023, 1, 1, 0, 0, 3)
+        travel_to @generated_time do
           post(
             :authenticate,
             params: {
@@ -93,11 +94,17 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
             format: :json
           )
         end
+        @user.webauthn_verification.reload
       end
 
       should respond_with :success
       should "return success message" do
         assert_equal "success", JSON.parse(response.body)["message"]
+      end
+
+      should "set OTP with expiry" do
+        assert_equal 20, @user.webauthn_verification.otp.length
+        assert_equal @generated_time + 2.minutes, @user.webauthn_verification.otp_expires_at
       end
 
       should "expire the path token by setting its expiry to 1 second prior" do
@@ -117,6 +124,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
             format: :json
           )
         end
+        @user.webauthn_verification.reload
       end
 
       should respond_with :unauthorized
@@ -127,6 +135,11 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       should "not expire the path token" do
         verification = WebauthnVerification.find_by!(path_token: @token)
         assert_equal Time.utc(2023, 1, 1, 0, 2, 0), verification.path_token_expires_at
+      end
+
+      should "not generate OTP" do
+        assert_nil @user.webauthn_verification.otp
+        assert_nil @user.webauthn_verification.otp_expires_at
       end
     end
 
@@ -159,6 +172,11 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       should respond_with :unauthorized
       should "return error message" do
         assert_equal "WebAuthn::ChallengeVerificationError", JSON.parse(response.body)["message"]
+      end
+
+      should "not generate OTP" do
+        assert_nil @user.webauthn_verification.otp
+        assert_nil @user.webauthn_verification.otp_expires_at
       end
     end
 

--- a/test/functional/webauthn_verifications_controller_test.rb
+++ b/test/functional/webauthn_verifications_controller_test.rb
@@ -64,7 +64,8 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       @user = create(:user)
       @webauthn_credential = create(:webauthn_credential, user: @user)
       travel_to Time.utc(2023, 1, 1, 0, 0, 0) do
-        @token = create(:webauthn_verification, user: @user, otp: nil, otp_expires_at: nil).path_token
+        @verification = create(:webauthn_verification, user: @user, otp: nil, otp_expires_at: nil)
+        @token = @verification.path_token
         get :prompt, params: { webauthn_token: @token }
       end
     end
@@ -94,7 +95,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
             format: :json
           )
         end
-        @user.webauthn_verification.reload
+        @verification.reload
       end
 
       should respond_with :success
@@ -124,7 +125,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
             format: :json
           )
         end
-        @user.webauthn_verification.reload
+        @verification.reload
       end
 
       should respond_with :unauthorized
@@ -138,8 +139,8 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       end
 
       should "not generate OTP" do
-        assert_nil @user.webauthn_verification.otp
-        assert_nil @user.webauthn_verification.otp_expires_at
+        assert_nil @verification.otp
+        assert_nil @verification.otp_expires_at
       end
     end
 
@@ -167,6 +168,7 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
             format: :json
           )
         end
+        @verification.reload
       end
 
       should respond_with :unauthorized
@@ -175,8 +177,8 @@ class WebauthnVerificationsControllerTest < ActionController::TestCase
       end
 
       should "not generate OTP" do
-        assert_nil @user.webauthn_verification.otp
-        assert_nil @user.webauthn_verification.otp_expires_at
+        assert_nil @verification.otp
+        assert_nil @verification.otp_expires_at
       end
     end
 

--- a/test/unit/webauthn_verification_test.rb
+++ b/test/unit/webauthn_verification_test.rb
@@ -50,4 +50,23 @@ class WebauthnVerificationTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "#generate_otp" do
+    setup do
+      @webauthn_verification = create(:webauthn_verification, otp: nil, otp_expires_at: nil)
+      @generated_time = Time.utc(2023, 1, 1, 0, 0, 0)
+      travel_to @generated_time do
+        @webauthn_verification.generate_otp
+      end
+      @webauthn_verification.reload
+    end
+
+    should "create a token that is 20 characters long" do
+      assert_equal 20, @webauthn_verification.otp.length
+    end
+
+    should "set a 2 minute expiry" do
+      assert_equal @generated_time + 2.minutes, @webauthn_verification.otp_expires_at
+    end
+  end
 end


### PR DESCRIPTION
Blocked by: https://github.com/rubygems/rubygems.org/pull/3334

## What problem are you solving?

Part of https://github.com/rubygems/rubygems.org/pull/3298

After successful verification of Webauthn credentials, an OTP needs generated to be sent to the client (either through manual pasting or sockets).

## What approach did you choose and why?
- Added a generate otp method on WebauthnVerification model
- After webauthn credentials are verified, generate the otp as `SecureRandom.base58(20)` with 2 minute expiry.

## What should reviewers focus on?
- is `SecureRandom.base58(20)` fine for the otp and 2 minutes as the expiry?

## Testing
1. Follow the tophat instructions from https://github.com/rubygems/rubygems.org/pull/3324 to get to the prompt page. You are able to authenticate your webauthn credential when clicking the button.
2. Check if an OTP is generated by going to the console and running `WebauthnVerification.find_by(path_token: "4MFRajUpoARwmt9w").otp`