### PR TITLE
Allow pushing CA gems

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -142,7 +142,7 @@ class Pusher
       #
       # Content-addressable (skinny) binaries are addressed by content, so a
       # byte-identical re-push is caught by find_or_initialize_by above. A
-      # different binary that targets the same Ruby minor is rejected by the
+      # different binary that targets the same Ruby ABI is rejected by the
       # uniqueness validations during #save, so we only guard the classic
       # name-version-platform address here.
       existing = existing_conflicting_version(version)
@@ -224,15 +224,15 @@ class Pusher
   # The existing version (if any) whose address conflicts with this push.
   #
   # A content-addressable push only conflicts with a byte-identical gem, which
-  # find_or_initialize_by has already loaded; a same-minor-different-content push
+  # find_or_initialize_by has already loaded; a same-ABI-different-content push
   # is rejected by the uniqueness validations. A classic (source/fat) push conflicts
-  # with any other source/fat gem (ruby_minor: "") for the same number+platform, but
+  # with any other source/fat gem (ruby_abi: "") for the same number+platform, but
   # is allowed to coexist with skinny binaries.
   def existing_conflicting_version(version)
     if version.content_addressed?
       version.persisted? ? version : nil
     else
-      @rubygem.versions.find_by(number: version.number, platform: version.platform, ruby_minor: "")
+      @rubygem.versions.find_by(number: version.number, platform: version.platform, ruby_abi: "")
     end
   end
 

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -60,7 +60,7 @@ class Pusher
 
     return notify("There was a problem saving your gem: #{rubygem.all_errors(version)}", 403) unless rubygem.valid? && version.valid?
 
-    unless version.full_name == spec.original_name && version.gem_full_name == spec.full_name
+    unless valid_platform_attributes?
       return notify("There was a problem saving your gem: the uploaded spec has malformed platform attributes", 409)
     end
 
@@ -129,15 +129,24 @@ class Pusher
         pusher_api_key: api_key
       )
 
+    # Needed before validation so content-addressable (skinny) binaries can be
+    # classified and named. It is set again from the spec during #save.
+    version.required_ruby_version = spec.required_ruby_version.to_s
+
     unless @rubygem.new_record?
       # Return success for idempotent pushes
       return notify("Gem was already pushed: #{version.to_title}", 200) if version.indexed?
 
       # If the gem is yanked, we can't repush it
-      # Additionally, we don't allow overwriting existing versions
-      if (existing = @rubygem.versions.find_by(number: version.number, platform: version.platform))
-        return republish_notification(existing)
-      end
+      # Additionally, we don't allow overwriting existing versions.
+      #
+      # Content-addressable (skinny) binaries are addressed by content, so a
+      # byte-identical re-push is caught by find_or_initialize_by above. A
+      # different binary that targets the same Ruby minor is rejected by the
+      # uniqueness validations during #save, so we only guard the classic
+      # name-version-platform address here.
+      existing = existing_conflicting_version(version)
+      return republish_notification(existing) if existing
 
       if @rubygem.name != name && @rubygem.indexed_versions?
         return notify("Unable to change case of gem name with indexed versions\n" \
@@ -200,6 +209,32 @@ class Pusher
   end
 
   private
+
+  # Content-addressable (skinny) binaries are addressed by content (name-version-sha)
+  # rather than by platform, so the classic full_name == original_name equality no
+  # longer holds. We instead verify the platform columns match the spec directly.
+  def valid_platform_attributes?
+    if version.content_addressed?
+      version.platform == spec.original_platform.to_s && version.gem_platform == spec.platform.to_s
+    else
+      version.full_name == spec.original_name && version.gem_full_name == spec.full_name
+    end
+  end
+
+  # The existing version (if any) whose address conflicts with this push.
+  #
+  # A content-addressable push only conflicts with a byte-identical gem, which
+  # find_or_initialize_by has already loaded; a same-minor-different-content push
+  # is rejected by the uniqueness validations. A classic (source/fat) push conflicts
+  # with any other source/fat gem (ruby_minor: "") for the same number+platform, but
+  # is allowed to coexist with skinny binaries.
+  def existing_conflicting_version(version)
+    if version.content_addressed?
+      version.persisted? ? version : nil
+    else
+      @rubygem.versions.find_by(number: version.number, platform: version.platform, ruby_minor: "")
+    end
+  end
 
   def after_write
     GemCachePurger.call(rubygem.name)

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -18,6 +18,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :attestations, dependent: :destroy, inverse_of: :version
 
   before_validation :set_canonical_number, if: :number_changed?
+  before_validation :set_ruby_minor
   before_validation :full_nameify!
   before_validation :gem_full_nameify!
   before_save :create_link_verifications, if: :metadata_changed?
@@ -454,6 +455,50 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     "#{full_name}.gem"
   end
 
+  # A "skinny" binary is a precompiled (platformed) gem whose required Ruby version
+  # pins exactly one MAJOR.MINOR series via a single pessimistic (`~>`) requirement,
+  # e.g. `~> 3.3.0`. These are content-addressable: multiple of them may coexist for
+  # the same number+platform as long as each targets a distinct Ruby minor series.
+  #
+  # Anything broader (`~> 3.3`, `>= 3.2, < 4.1`, blank, multiple clauses) is a "fat"
+  # binary and keeps the classic name-version-platform addressing.
+  def content_addressed?
+    platformed? && ruby_minor_series.present?
+  end
+
+  # The MAJOR.MINOR series a skinny binary targets, or nil for fat/source gems.
+  def ruby_minor_series
+    return nil unless platformed?
+    self.class.skinny_ruby_minor(required_ruby_version)
+  end
+
+  # The content address fragment used in the gem file name for skinny binaries:
+  # the first 10 hex characters of the gem's SHA256.
+  def content_address
+    sha256_hex&.first(10)
+  end
+
+  # Parses a required_ruby_version string and returns the single "MAJOR.MINOR"
+  # series it pins, or nil if it does not pin exactly one minor series.
+  def self.skinny_ruby_minor(required_ruby_version)
+    return nil if required_ruby_version.blank?
+
+    requirement = Gem::Requirement.new(required_ruby_version.to_s.split(",").map(&:strip))
+    constraints = requirement.requirements
+    return nil unless constraints.size == 1
+
+    operator, version = constraints.first
+    return nil unless operator == "~>"
+
+    segments = version.segments
+    # `~> 3.3.0` pins minor 3.3; `~> 3.3` only pins major 3 (spans many minors).
+    return nil unless segments.size >= 3
+
+    segments.first(2).join(".")
+  rescue Gem::Requirement::BadRequirementError, ArgumentError
+    nil
+  end
+
   private
 
   def update_prerelease
@@ -461,12 +506,16 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def platform_and_number_are_unique
-    return unless Version.exists?(rubygem_id: rubygem_id, number: number, platform: platform)
-    errors.add(:base, "A version already exists with this number or platform.")
+    return unless Version.exists?(rubygem_id: rubygem_id, number: number, platform: platform, ruby_minor: ruby_minor)
+    if content_addressed?
+      errors.add(:base, "A version already exists with this number, platform, and Ruby version (#{ruby_minor_series}).")
+    else
+      errors.add(:base, "A version already exists with this number or platform.")
+    end
   end
 
   def gem_platform_and_number_are_unique
-    platforms = Version.where(rubygem_id: rubygem_id, number: number, gem_platform: gem_platform).pluck(:platform)
+    platforms = Version.where(rubygem_id: rubygem_id, number: number, gem_platform: gem_platform, ruby_minor: ruby_minor).pluck(:platform)
     return if platforms.empty?
     errors.add(:base, "A version already exists with this number and resolved platform #{platforms}")
   end
@@ -485,17 +534,33 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     errors.add :authors, "must be an Array of Strings"
   end
 
+  # Content-addressable (skinny) binaries are addressed by content: their file name
+  # is name-version-<sha10> so multiple binaries for the same number+platform that
+  # target different Ruby minors never collide. Source and fat binaries keep the
+  # classic name-version[-platform] addressing.
+  def set_ruby_minor
+    self.ruby_minor = ruby_minor_series.to_s
+  end
+
   def full_nameify!
     return if rubygem.nil?
-    self.full_name = "#{rubygem.name}-#{number}"
-    full_name << "-#{platform}" if platformed?
+    if content_addressed?
+      self.full_name = "#{rubygem.name}-#{number}-#{content_address}"
+    else
+      self.full_name = "#{rubygem.name}-#{number}"
+      full_name << "-#{platform}" if platformed?
+    end
   end
 
   def gem_full_nameify!
     return if gem_platform.blank?
     return if rubygem.nil?
-    self.gem_full_name = "#{rubygem.name}-#{number}"
-    gem_full_name << "-#{gem_platform}" unless gem_platform == "ruby"
+    if content_addressed?
+      self.gem_full_name = "#{rubygem.name}-#{number}-#{content_address}"
+    else
+      self.gem_full_name = "#{rubygem.name}-#{number}"
+      gem_full_name << "-#{gem_platform}" unless gem_platform == "ruby"
+    end
   end
 
   def set_canonical_number
@@ -530,7 +595,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def unique_canonical_number
-    version = Version.find_by(canonical_number: canonical_number, rubygem_id: rubygem_id, platform: platform)
+    version = Version.find_by(canonical_number: canonical_number, rubygem_id: rubygem_id, platform: platform, ruby_minor: ruby_minor)
     errors.add(:canonical_number, "has already been taken. Existing version: #{version.number}") unless version.nil?
   end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -18,7 +18,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :attestations, dependent: :destroy, inverse_of: :version
 
   before_validation :set_canonical_number, if: :number_changed?
-  before_validation :set_ruby_minor
+  before_validation :set_ruby_abi
   before_validation :full_nameify!
   before_validation :gem_full_nameify!
   before_save :create_link_verifications, if: :metadata_changed?
@@ -458,18 +458,18 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # A "skinny" binary is a precompiled (platformed) gem whose required Ruby version
   # pins exactly one MAJOR.MINOR series via a single pessimistic (`~>`) requirement,
   # e.g. `~> 3.3.0`. These are content-addressable: multiple of them may coexist for
-  # the same number+platform as long as each targets a distinct Ruby minor series.
+  # the same number+platform as long as each targets a distinct Ruby ABI series.
   #
   # Anything broader (`~> 3.3`, `>= 3.2, < 4.1`, blank, multiple clauses) is a "fat"
   # binary and keeps the classic name-version-platform addressing.
   def content_addressed?
-    platformed? && ruby_minor_series.present?
+    platformed? && ruby_abi_series.present?
   end
 
   # The MAJOR.MINOR series a skinny binary targets, or nil for fat/source gems.
-  def ruby_minor_series
+  def ruby_abi_series
     return nil unless platformed?
-    self.class.skinny_ruby_minor(required_ruby_version)
+    self.class.skinny_ruby_abi(required_ruby_version)
   end
 
   # The content address fragment used in the gem file name for skinny binaries:
@@ -479,8 +479,8 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   # Parses a required_ruby_version string and returns the single "MAJOR.MINOR"
-  # series it pins, or nil if it does not pin exactly one minor series.
-  def self.skinny_ruby_minor(required_ruby_version)
+  # series it pins, or nil if it does not pin exactly one ABI.
+  def self.skinny_ruby_abi(required_ruby_version)
     return nil if required_ruby_version.blank?
 
     requirement = Gem::Requirement.new(required_ruby_version.to_s.split(",").map(&:strip))
@@ -491,7 +491,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     return nil unless operator == "~>"
 
     segments = version.segments
-    # `~> 3.3.0` pins minor 3.3; `~> 3.3` only pins major 3 (spans many minors).
+    # `~> 3.3.0` pins ABI 3.3; `~> 3.3` only pins major 3 (spans many versions).
     return nil unless segments.size >= 3
 
     segments.first(2).join(".")
@@ -506,16 +506,16 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def platform_and_number_are_unique
-    return unless Version.exists?(rubygem_id: rubygem_id, number: number, platform: platform, ruby_minor: ruby_minor)
+    return unless Version.exists?(rubygem_id: rubygem_id, number: number, platform: platform, ruby_abi: ruby_abi)
     if content_addressed?
-      errors.add(:base, "A version already exists with this number, platform, and Ruby version (#{ruby_minor_series}).")
+      errors.add(:base, "A version already exists with this number, platform, and Ruby ABI (#{ruby_abi_series}).")
     else
       errors.add(:base, "A version already exists with this number or platform.")
     end
   end
 
   def gem_platform_and_number_are_unique
-    platforms = Version.where(rubygem_id: rubygem_id, number: number, gem_platform: gem_platform, ruby_minor: ruby_minor).pluck(:platform)
+    platforms = Version.where(rubygem_id: rubygem_id, number: number, gem_platform: gem_platform, ruby_abi: ruby_abi).pluck(:platform)
     return if platforms.empty?
     errors.add(:base, "A version already exists with this number and resolved platform #{platforms}")
   end
@@ -536,10 +536,10 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   # Content-addressable (skinny) binaries are addressed by content: their file name
   # is name-version-<sha10> so multiple binaries for the same number+platform that
-  # target different Ruby minors never collide. Source and fat binaries keep the
+  # target different Ruby ABIs never collide. Source and fat binaries keep the
   # classic name-version[-platform] addressing.
-  def set_ruby_minor
-    self.ruby_minor = ruby_minor_series.to_s
+  def set_ruby_abi
+    self.ruby_abi = ruby_abi_series.to_s
   end
 
   def full_nameify!
@@ -595,7 +595,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def unique_canonical_number
-    version = Version.find_by(canonical_number: canonical_number, rubygem_id: rubygem_id, platform: platform, ruby_minor: ruby_minor)
+    version = Version.find_by(canonical_number: canonical_number, rubygem_id: rubygem_id, platform: platform, ruby_abi: ruby_abi)
     errors.add(:canonical_number, "has already been taken. Existing version: #{version.number}") unless version.nil?
   end
 

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -4,6 +4,9 @@
   <% if version.platformed? %>
     <span class="gem__version__date platform"><%= version.platform %></span>
   <% end %>
+  <% if version.ruby_minor.present? %>
+    <span class="gem__version__date ruby"><%= t('.ruby', version: version.ruby_minor) %></span>
+  <% end %>
 
   <span class="gem__version__date">(<%= number_to_human_size(version.size) %>)</span>
   <% if version.yanked? -%>

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -4,8 +4,8 @@
   <% if version.platformed? %>
     <span class="gem__version__date platform"><%= version.platform %></span>
   <% end %>
-  <% if version.ruby_minor.present? %>
-    <span class="gem__version__date ruby"><%= t('.ruby', version: version.ruby_minor) %></span>
+  <% if version.ruby_abi.present? %>
+    <span class="gem__version__date ruby"><%= t('.ruby', version: version.ruby_abi) %></span>
   <% end %>
 
   <span class="gem__version__date">(<%= number_to_human_size(version.size) %>)</span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -909,6 +909,7 @@ en:
       imported_gem_version_notice: "This gem version was imported to RubyGems.org on %{import_date}. The date displayed was specified by the author in the gemspec."
     version:
       yanked: yanked
+      ruby: "Ruby %{version}"
   webauthn_credentials:
     callback:
       success: You have successfully registered a security device.

--- a/db/migrate/20260604133906_add_ruby_abi_to_versions.rb
+++ b/db/migrate/20260604133906_add_ruby_abi_to_versions.rb
@@ -1,38 +1,38 @@
 # frozen_string_literal: true
 
-class AddRubyMinorToVersions < ActiveRecord::Migration[8.1]
+class AddRubyAbiToVersions < ActiveRecord::Migration[8.1]
   disable_ddl_transaction!
 
   def up
-    unless column_exists?(:versions, :ruby_minor)
-      # Captures the single Ruby MAJOR.MINOR series a "skinny" content-addressable
+    unless column_exists?(:versions, :ruby_abi)
+      # Captures the single Ruby ABI a "skinny" content-addressable
       # binary targets (e.g. "3.3"). Empty for source gems and "fat" binaries, which
       # preserves the existing one-per-(number, platform) uniqueness for them.
-      add_column :versions, :ruby_minor, :string, default: "", null: false
+      add_column :versions, :ruby_abi, :string, default: "", null: false
     end
 
     remove_index :versions,
       name: "index_versions_on_rubygem_id_and_number_and_platform",
       algorithm: :concurrently
     add_index :versions,
-      %i[rubygem_id number platform ruby_minor],
+      %i[rubygem_id number platform ruby_abi],
       unique: true,
-      name: "index_versions_on_rubygem_number_platform_ruby_minor",
+      name: "index_versions_on_rubygem_number_platform_ruby_abi",
       algorithm: :concurrently
 
     remove_index :versions,
       name: "index_versions_on_canonical_number_and_rubygem_id_and_platform",
       algorithm: :concurrently
     add_index :versions,
-      %i[canonical_number rubygem_id platform ruby_minor],
+      %i[canonical_number rubygem_id platform ruby_abi],
       unique: true,
-      name: "index_versions_on_canonical_rubygem_platform_ruby_minor",
+      name: "index_versions_on_canonical_rubygem_platform_ruby_abi",
       algorithm: :concurrently
   end
 
   def down
     remove_index :versions,
-      name: "index_versions_on_rubygem_number_platform_ruby_minor",
+      name: "index_versions_on_rubygem_number_platform_ruby_abi",
       algorithm: :concurrently
     add_index :versions,
       %i[rubygem_id number platform],
@@ -41,7 +41,7 @@ class AddRubyMinorToVersions < ActiveRecord::Migration[8.1]
       algorithm: :concurrently
 
     remove_index :versions,
-      name: "index_versions_on_canonical_rubygem_platform_ruby_minor",
+      name: "index_versions_on_canonical_rubygem_platform_ruby_abi",
       algorithm: :concurrently
     add_index :versions,
       %i[canonical_number rubygem_id platform],
@@ -49,6 +49,6 @@ class AddRubyMinorToVersions < ActiveRecord::Migration[8.1]
       name: "index_versions_on_canonical_number_and_rubygem_id_and_platform",
       algorithm: :concurrently
 
-    remove_column :versions, :ruby_minor
+    remove_column :versions, :ruby_abi
   end
 end

--- a/db/migrate/20260604133906_add_ruby_minor_to_versions.rb
+++ b/db/migrate/20260604133906_add_ruby_minor_to_versions.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class AddRubyMinorToVersions < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    unless column_exists?(:versions, :ruby_minor)
+      # Captures the single Ruby MAJOR.MINOR series a "skinny" content-addressable
+      # binary targets (e.g. "3.3"). Empty for source gems and "fat" binaries, which
+      # preserves the existing one-per-(number, platform) uniqueness for them.
+      add_column :versions, :ruby_minor, :string, default: "", null: false
+    end
+
+    remove_index :versions,
+      name: "index_versions_on_rubygem_id_and_number_and_platform",
+      algorithm: :concurrently
+    add_index :versions,
+      %i[rubygem_id number platform ruby_minor],
+      unique: true,
+      name: "index_versions_on_rubygem_number_platform_ruby_minor",
+      algorithm: :concurrently
+
+    remove_index :versions,
+      name: "index_versions_on_canonical_number_and_rubygem_id_and_platform",
+      algorithm: :concurrently
+    add_index :versions,
+      %i[canonical_number rubygem_id platform ruby_minor],
+      unique: true,
+      name: "index_versions_on_canonical_rubygem_platform_ruby_minor",
+      algorithm: :concurrently
+  end
+
+  def down
+    remove_index :versions,
+      name: "index_versions_on_rubygem_number_platform_ruby_minor",
+      algorithm: :concurrently
+    add_index :versions,
+      %i[rubygem_id number platform],
+      unique: true,
+      name: "index_versions_on_rubygem_id_and_number_and_platform",
+      algorithm: :concurrently
+
+    remove_index :versions,
+      name: "index_versions_on_canonical_rubygem_platform_ruby_minor",
+      algorithm: :concurrently
+    add_index :versions,
+      %i[canonical_number rubygem_id platform],
+      unique: true,
+      name: "index_versions_on_canonical_number_and_rubygem_id_and_platform",
+      algorithm: :concurrently
+
+    remove_column :versions, :ruby_minor
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_26_195603) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_04_133906) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -714,6 +714,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_195603) do
     t.string "required_ruby_version"
     t.string "required_rubygems_version", limit: 255
     t.text "requirements"
+    t.string "ruby_minor", default: "", null: false
     t.integer "rubygem_id"
     t.string "sha256"
     t.integer "size"
@@ -726,7 +727,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_195603) do
     t.index "lower((full_name)::text)", name: "index_versions_on_lower_full_name"
     t.index "lower((gem_full_name)::text)", name: "index_versions_on_lower_gem_full_name"
     t.index ["built_at"], name: "index_versions_on_built_at"
-    t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_on_canonical_number_and_rubygem_id_and_platform", unique: true
+    t.index ["canonical_number", "rubygem_id", "platform", "ruby_minor"], name: "index_versions_on_canonical_rubygem_platform_ruby_minor", unique: true
     t.index ["created_at"], name: "index_versions_on_created_at"
     t.index ["full_name"], name: "index_versions_on_full_name"
     t.index ["indexed", "yanked_at"], name: "index_versions_on_indexed_and_yanked_at"
@@ -735,7 +736,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_195603) do
     t.index ["prerelease"], name: "index_versions_on_prerelease"
     t.index ["pusher_api_key_id"], name: "index_versions_on_pusher_api_key_id"
     t.index ["pusher_id"], name: "index_versions_on_pusher_id"
-    t.index ["rubygem_id", "number", "platform"], name: "index_versions_on_rubygem_id_and_number_and_platform", unique: true
+    t.index ["rubygem_id", "number", "platform", "ruby_minor"], name: "index_versions_on_rubygem_number_platform_ruby_minor", unique: true
     t.index ["rubygem_id", "position", "created_at"], name: "index_versions_on_rubygem_id_and_position_and_created_at", order: { created_at: :desc }, where: "(indexed = true)", include: ["full_name", "number", "platform"]
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -714,7 +714,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_133906) do
     t.string "required_ruby_version"
     t.string "required_rubygems_version", limit: 255
     t.text "requirements"
-    t.string "ruby_minor", default: "", null: false
+    t.string "ruby_abi", default: "", null: false
     t.integer "rubygem_id"
     t.string "sha256"
     t.integer "size"
@@ -727,7 +727,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_133906) do
     t.index "lower((full_name)::text)", name: "index_versions_on_lower_full_name"
     t.index "lower((gem_full_name)::text)", name: "index_versions_on_lower_gem_full_name"
     t.index ["built_at"], name: "index_versions_on_built_at"
-    t.index ["canonical_number", "rubygem_id", "platform", "ruby_minor"], name: "index_versions_on_canonical_rubygem_platform_ruby_minor", unique: true
+    t.index ["canonical_number", "rubygem_id", "platform", "ruby_abi"], name: "index_versions_on_canonical_rubygem_platform_ruby_abi", unique: true
     t.index ["created_at"], name: "index_versions_on_created_at"
     t.index ["full_name"], name: "index_versions_on_full_name"
     t.index ["indexed", "yanked_at"], name: "index_versions_on_indexed_and_yanked_at"
@@ -736,7 +736,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_04_133906) do
     t.index ["prerelease"], name: "index_versions_on_prerelease"
     t.index ["pusher_api_key_id"], name: "index_versions_on_pusher_api_key_id"
     t.index ["pusher_id"], name: "index_versions_on_pusher_id"
-    t.index ["rubygem_id", "number", "platform", "ruby_minor"], name: "index_versions_on_rubygem_number_platform_ruby_minor", unique: true
+    t.index ["rubygem_id", "number", "platform", "ruby_abi"], name: "index_versions_on_rubygem_number_platform_ruby_abi", unique: true
     t.index ["rubygem_id", "position", "created_at"], name: "index_versions_on_rubygem_id_and_position_and_created_at", order: { created_at: :desc }, where: "(indexed = true)", include: ["full_name", "number", "platform"]
   end
 

--- a/test/integration/pusher_test.rb
+++ b/test/integration/pusher_test.rb
@@ -603,4 +603,95 @@ class PusherIntegrationTest < ActiveSupport::TestCase
       RubygemFs.mock!
     end
   end
+
+  def push_binary(platform:, ruby_version:, name: "sqlite3", version: "2.9.0")
+    spec = new_gemspec(name, version, "summary", platform, ruby_version: ruby_version)
+    cutter = Pusher.new(@api_key, build_gem(spec))
+    cutter.process
+    cutter
+  end
+
+  context "content addressable (skinny/fat binary) gems" do
+    should "address a skinny binary (~> X.Y.Z) by content as name-version-sha" do
+      cutter = push_binary(platform: "x86_64-linux", ruby_version: "~> 3.3.0")
+
+      assert_equal 200, cutter.code
+      version = cutter.version
+
+      assert_predicate version, :content_addressed?
+      assert_equal "3.3", version.ruby_minor
+      assert_match(/\Asqlite3-2\.9\.0-[0-9a-f]{10}\z/, version.full_name)
+      assert_equal version.full_name, version.gem_full_name
+      assert_equal "x86_64-linux", version.platform
+    end
+
+    should "keep a fat binary (ruby range) addressed as name-version-platform" do
+      cutter = push_binary(platform: "x86_64-linux", ruby_version: [">= 3.2", "< 4.1"])
+
+      assert_equal 200, cutter.code
+      version = cutter.version
+
+      refute_predicate version, :content_addressed?
+      assert_equal "", version.ruby_minor
+      assert_equal "sqlite3-2.9.0-x86_64-linux", version.full_name
+    end
+
+    should "treat ~> 3.3 (major-only pin) as a fat binary, not content addressed" do
+      cutter = push_binary(platform: "x86_64-linux", ruby_version: "~> 3.3")
+
+      assert_equal 200, cutter.code
+      refute_predicate cutter.version, :content_addressed?
+      assert_equal "sqlite3-2.9.0-x86_64-linux", cutter.version.full_name
+    end
+
+    should "address source (ruby platform) gems the classic way even with a ~> X.Y.Z ruby" do
+      cutter = push_binary(platform: "ruby", ruby_version: "~> 3.3.0")
+
+      assert_equal 200, cutter.code
+      refute_predicate cutter.version, :content_addressed?
+      assert_equal "sqlite3-2.9.0", cutter.version.full_name
+    end
+
+    should "accept multiple skinny binaries targeting different ruby minors" do
+      first  = push_binary(platform: "x86_64-linux", ruby_version: "~> 3.3.0")
+      second = push_binary(platform: "x86_64-linux", ruby_version: "~> 3.4.0")
+
+      assert_equal 200, first.code
+      assert_equal 200, second.code
+
+      versions = Rubygem.find_by(name: "sqlite3").versions.where(number: "2.9.0", platform: "x86_64-linux")
+
+      assert_equal 2, versions.count
+      assert_equal %w[3.3 3.4], versions.pluck(:ruby_minor).sort
+      assert_equal 2, versions.pluck(:full_name).uniq.size
+    end
+
+    should "reject a second skinny binary that targets the same ruby minor (no duplicates)" do
+      first = push_binary(platform: "x86_64-linux", ruby_version: "~> 3.3.0")
+      dup   = push_binary(platform: "x86_64-linux", ruby_version: "~> 3.3.5") # same minor 3.3
+
+      assert_equal 200, first.code
+      assert_equal 403, dup.code
+      assert_match(/Ruby version \(3\.3\)/, dup.message)
+      assert_equal 1, Rubygem.find_by(name: "sqlite3").versions.where(number: "2.9.0", platform: "x86_64-linux").count
+    end
+
+    should "allow a skinny binary to coexist with a fat binary on the same platform" do
+      fat    = push_binary(platform: "x86_64-linux", ruby_version: [">= 3.2", "< 4.1"])
+      skinny = push_binary(platform: "x86_64-linux", ruby_version: "~> 3.3.0")
+
+      assert_equal 200, fat.code
+      assert_equal 200, skinny.code
+      assert_equal 2, Rubygem.find_by(name: "sqlite3").versions.where(number: "2.9.0", platform: "x86_64-linux").count
+    end
+
+    should "reject a second fat binary on the same platform" do
+      first  = push_binary(platform: "x86_64-linux", ruby_version: [">= 3.2", "< 4.1"])
+      second = push_binary(platform: "x86_64-linux", ruby_version: ">= 3.0")
+
+      assert_equal 200, first.code
+      assert_equal 409, second.code
+      assert_match(/Repushing of gem versions is not allowed/, second.message)
+    end
+  end
 end

--- a/test/integration/pusher_test.rb
+++ b/test/integration/pusher_test.rb
@@ -619,7 +619,7 @@ class PusherIntegrationTest < ActiveSupport::TestCase
       version = cutter.version
 
       assert_predicate version, :content_addressed?
-      assert_equal "3.3", version.ruby_minor
+      assert_equal "3.3", version.ruby_abi
       assert_match(/\Asqlite3-2\.9\.0-[0-9a-f]{10}\z/, version.full_name)
       assert_equal version.full_name, version.gem_full_name
       assert_equal "x86_64-linux", version.platform
@@ -632,7 +632,7 @@ class PusherIntegrationTest < ActiveSupport::TestCase
       version = cutter.version
 
       refute_predicate version, :content_addressed?
-      assert_equal "", version.ruby_minor
+      assert_equal "", version.ruby_abi
       assert_equal "sqlite3-2.9.0-x86_64-linux", version.full_name
     end
 
@@ -652,7 +652,7 @@ class PusherIntegrationTest < ActiveSupport::TestCase
       assert_equal "sqlite3-2.9.0", cutter.version.full_name
     end
 
-    should "accept multiple skinny binaries targeting different ruby minors" do
+    should "accept multiple skinny binaries targeting different ruby ABIs" do
       first  = push_binary(platform: "x86_64-linux", ruby_version: "~> 3.3.0")
       second = push_binary(platform: "x86_64-linux", ruby_version: "~> 3.4.0")
 
@@ -662,17 +662,17 @@ class PusherIntegrationTest < ActiveSupport::TestCase
       versions = Rubygem.find_by(name: "sqlite3").versions.where(number: "2.9.0", platform: "x86_64-linux")
 
       assert_equal 2, versions.count
-      assert_equal %w[3.3 3.4], versions.pluck(:ruby_minor).sort
+      assert_equal %w[3.3 3.4], versions.pluck(:ruby_abi).sort
       assert_equal 2, versions.pluck(:full_name).uniq.size
     end
 
-    should "reject a second skinny binary that targets the same ruby minor (no duplicates)" do
+    should "reject a second skinny binary that targets the same ruby ABI (no duplicates)" do
       first = push_binary(platform: "x86_64-linux", ruby_version: "~> 3.3.0")
-      dup   = push_binary(platform: "x86_64-linux", ruby_version: "~> 3.3.5") # same minor 3.3
+      dup   = push_binary(platform: "x86_64-linux", ruby_version: "~> 3.3.5") # same ABI 3.3
 
       assert_equal 200, first.code
       assert_equal 403, dup.code
-      assert_match(/Ruby version \(3\.3\)/, dup.message)
+      assert_match(/Ruby ABI \(3\.3\)/, dup.message)
       assert_equal 1, Rubygem.find_by(name: "sqlite3").versions.where(number: "2.9.0", platform: "x86_64-linux").count
     end
 

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -149,6 +149,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.expects(:original_platform).returns "ruby"
       spec.expects(:platform).returns "ruby"
       spec.expects(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns(Gem::Requirement.default)
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
       @cutter.stubs(:size).returns 5
@@ -194,6 +195,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:platform).returns "ruby"
       spec.stubs(:cert_chain).returns nil
       spec.stubs(:metadata).returns({})
+      spec.stubs(:required_ruby_version).returns(Gem::Requirement.default)
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
       @cutter.find
@@ -214,6 +216,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.expects(:platform).returns "ruby"
       spec.expects(:original_platform).returns "ruby"
       spec.expects(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns(Gem::Requirement.default)
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
 
@@ -234,6 +237,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:platform).returns "ruby"
       spec.stubs(:cert_chain).returns nil
       spec.stubs(:metadata).returns({})
+      spec.stubs(:required_ruby_version).returns(Gem::Requirement.default)
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
       @cutter.find
@@ -255,6 +259,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:original_platform).returns "universal-darwin-6000"
       spec.stubs(:platform).returns Gem::Platform.new("universal-darwin-6000")
       spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns(Gem::Requirement.default)
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
 

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -7,19 +7,19 @@ class VersionTest < ActiveSupport::TestCase
   should have_many :dependencies
 
   context "content addressable binaries" do
-    context ".skinny_ruby_minor" do
+    context ".skinny_ruby_abi" do
       should "return the MAJOR.MINOR for a single ~> X.Y.Z pin" do
-        assert_equal "3.3", Version.skinny_ruby_minor("~> 3.3.0")
-        assert_equal "3.4", Version.skinny_ruby_minor("~> 3.4.5")
-        assert_equal "3.3", Version.skinny_ruby_minor("~> 3.3.0.1")
+        assert_equal "3.3", Version.skinny_ruby_abi("~> 3.3.0")
+        assert_equal "3.4", Version.skinny_ruby_abi("~> 3.4.5")
+        assert_equal "3.3", Version.skinny_ruby_abi("~> 3.3.0.1")
       end
 
-      should "return nil for anything that does not pin exactly one minor" do
-        assert_nil Version.skinny_ruby_minor("~> 3.3")       # major-only pin
-        assert_nil Version.skinny_ruby_minor(">= 3.2, < 4.1") # range
-        assert_nil Version.skinny_ruby_minor(">= 3.0")
-        assert_nil Version.skinny_ruby_minor("")
-        assert_nil Version.skinny_ruby_minor(nil)
+      should "return nil for anything that does not pin exactly one ABI" do
+        assert_nil Version.skinny_ruby_abi("~> 3.3")       # major-only pin
+        assert_nil Version.skinny_ruby_abi(">= 3.2, < 4.1") # range
+        assert_nil Version.skinny_ruby_abi(">= 3.0")
+        assert_nil Version.skinny_ruby_abi("")
+        assert_nil Version.skinny_ruby_abi(nil)
       end
     end
 
@@ -27,14 +27,14 @@ class VersionTest < ActiveSupport::TestCase
       version = build(:version, platform: "x86_64-linux", required_ruby_version: "~> 3.3.0")
 
       assert_predicate version, :content_addressed?
-      assert_equal "3.3", version.ruby_minor_series
+      assert_equal "3.3", version.ruby_abi_series
     end
 
     should "classify ~> X.Y (major-only) as a fat binary" do
       version = build(:version, platform: "x86_64-linux", required_ruby_version: "~> 3.3")
 
       refute_predicate version, :content_addressed?
-      assert_nil version.ruby_minor_series
+      assert_nil version.ruby_abi_series
     end
 
     should "classify a ruby range as a fat binary" do
@@ -47,7 +47,7 @@ class VersionTest < ActiveSupport::TestCase
       version = build(:version, platform: "ruby", required_ruby_version: "~> 3.3.0")
 
       refute_predicate version, :content_addressed?
-      assert_nil version.ruby_minor_series
+      assert_nil version.ruby_abi_series
     end
 
     should "address a skinny binary by content in full_name and gem_full_name" do
@@ -56,7 +56,7 @@ class VersionTest < ActiveSupport::TestCase
 
       assert_match(/\A#{version.rubygem.name}-#{version.number}-[0-9a-f]{10}\z/, version.full_name)
       assert_equal version.full_name, version.gem_full_name
-      assert_equal "3.3", version.ruby_minor
+      assert_equal "3.3", version.ruby_abi
     end
 
     should "keep classic platform addressing for fat binaries" do
@@ -64,7 +64,7 @@ class VersionTest < ActiveSupport::TestCase
       version.validate
 
       assert_equal "#{version.rubygem.name}-#{version.number}-x86_64-linux", version.full_name
-      assert_equal "", version.ruby_minor
+      assert_equal "", version.ruby_abi
     end
   end
 

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -6,6 +6,68 @@ class VersionTest < ActiveSupport::TestCase
   should belong_to :rubygem
   should have_many :dependencies
 
+  context "content addressable binaries" do
+    context ".skinny_ruby_minor" do
+      should "return the MAJOR.MINOR for a single ~> X.Y.Z pin" do
+        assert_equal "3.3", Version.skinny_ruby_minor("~> 3.3.0")
+        assert_equal "3.4", Version.skinny_ruby_minor("~> 3.4.5")
+        assert_equal "3.3", Version.skinny_ruby_minor("~> 3.3.0.1")
+      end
+
+      should "return nil for anything that does not pin exactly one minor" do
+        assert_nil Version.skinny_ruby_minor("~> 3.3")       # major-only pin
+        assert_nil Version.skinny_ruby_minor(">= 3.2, < 4.1") # range
+        assert_nil Version.skinny_ruby_minor(">= 3.0")
+        assert_nil Version.skinny_ruby_minor("")
+        assert_nil Version.skinny_ruby_minor(nil)
+      end
+    end
+
+    should "classify a single ~> X.Y.Z platform gem as a content-addressed skinny binary" do
+      version = build(:version, platform: "x86_64-linux", required_ruby_version: "~> 3.3.0")
+
+      assert_predicate version, :content_addressed?
+      assert_equal "3.3", version.ruby_minor_series
+    end
+
+    should "classify ~> X.Y (major-only) as a fat binary" do
+      version = build(:version, platform: "x86_64-linux", required_ruby_version: "~> 3.3")
+
+      refute_predicate version, :content_addressed?
+      assert_nil version.ruby_minor_series
+    end
+
+    should "classify a ruby range as a fat binary" do
+      version = build(:version, platform: "x86_64-linux", required_ruby_version: ">= 3.2, < 4.1")
+
+      refute_predicate version, :content_addressed?
+    end
+
+    should "never treat a source (ruby platform) gem as content addressed" do
+      version = build(:version, platform: "ruby", required_ruby_version: "~> 3.3.0")
+
+      refute_predicate version, :content_addressed?
+      assert_nil version.ruby_minor_series
+    end
+
+    should "address a skinny binary by content in full_name and gem_full_name" do
+      version = build(:version, platform: "x86_64-linux", required_ruby_version: "~> 3.3.0")
+      version.validate
+
+      assert_match(/\A#{version.rubygem.name}-#{version.number}-[0-9a-f]{10}\z/, version.full_name)
+      assert_equal version.full_name, version.gem_full_name
+      assert_equal "3.3", version.ruby_minor
+    end
+
+    should "keep classic platform addressing for fat binaries" do
+      version = build(:version, platform: "x86_64-linux", required_ruby_version: ">= 3.2, < 4.1")
+      version.validate
+
+      assert_equal "#{version.rubygem.name}-#{version.number}-x86_64-linux", version.full_name
+      assert_equal "", version.ruby_minor
+    end
+  end
+
   context "#as_json" do
     setup do
       @version = build(:version, summary: "some words", created_at: Time.now.in_time_zone)


### PR DESCRIPTION
## The problem

Today a precompiled gem is "addressed" by `name-version-platform` (e.g.
`sqlite3-2.9.0-x86_64-linux.gem`), and a `(rubygem, version, platform)` triple is
globally unique. To support multiple Ruby versions, maintainers ship one **fat
binary** that bundles `.so` files for every Ruby minor (3.2, 3.3, 3.4, …), plus
runtime logic to load the right one. That makes gems bigger to download and
harder to maintain.

This change lets maintainers instead push multiple **skinny binaries** — one
precompiled gem per Ruby minor — addressed by the **content hash** of the gem
rather than by platform, so they don't collide.

## The core rule

Classification is driven entirely by `required_ruby_version`:

- **Skinny** = a single pessimistic pin `~> X.Y.Z` (≥ 3 segments, so it pins
  exactly one Ruby minor, e.g. `~> 3.3.0` → `3.3`). These are
  **content-addressed**: `full_name = name-version-<sha10>`. Multiple may coexist
  for the same `number + platform`, but **only one per Ruby minor** (no
  duplicates).
- **Fat** = anything broader (`~> 3.3`, `>= 3.2, < 4.1`, blank, multi-clause).
  Keeps the classic `name-version-platform` addressing. **One fat per platform**,
  and it can coexist with skinny binaries.
- **Source** gems (`platform == ruby`) are unchanged.

## What each file does

### `app/models/version.rb` (the heart of it)

- `Version.skinny_ruby_minor(req)` — parses `required_ruby_version`; returns
  `"3.3"` only for a clean single `~> X.Y.Z`, otherwise `nil`.
- `content_addressed?` / `ruby_minor_series` / `content_address` — classify a
  version and compute its sha-based address.
- `full_nameify!` / `gem_full_nameify!` — produce `name-version-<sha10>` for
  skinny binaries, classic names otherwise.
- `set_ruby_minor` (`before_validation`) — stores the normalized minor in the
  `ruby_minor` column.
- Uniqueness validations (`platform_and_number_are_unique`,
  `gem_platform_and_number_are_unique`, `unique_canonical_number`) now scope on
  `ruby_minor`, so same-minor duplicates are rejected while different minors
  coexist.

### `app/models/pusher.rb`

- Sets `required_ruby_version` early in `find` so the version can be classified
  and named before validation runs.
- `valid_platform_attributes?` — content-address-aware replacement for the old
  `full_name == original_name` integrity check.
- `existing_conflicting_version` — a fat/source push conflicts only with another
  fat/source on the same platform; skinny conflicts are left to the uniqueness
  validations.

### `db/migrate/20260604133906_add_ruby_minor_to_versions.rb` + `db/schema.rb`

- Adds the `ruby_minor` column and extends the two `versions` unique indexes to
  include it. This enforces the rules at the DB level: `""` for fat/source keeps
  one-fat-per-platform; distinct minors allow multiple skinny binaries.

### `app/views/versions/_version.html.erb` + `config/locales/en.yml`

- Adds a `Ruby 3.3` / `Ruby 3.4` badge next to the platform on the gem page
  version list, so two same-platform skinny entries are distinguishable.

### Tests + demo

- `test/integration/pusher_test.rb`, `test/models/version_test.rb`, and updated
  mocks in `test/models/pusher_test.rb`.
- `setup/content_addressable_push_demo.rb` — a development-only smoke-test script
  that builds skinny/fat gems in-process and pushes them through `Pusher`.

## Verified behavior (pushed to a dev server over HTTP)

| Push                            | Result                                   |
| ------------------------------- | ---------------------------------------- |
| skinny `~> 3.3.0`               | ✅ `name-0.0.1-<sha>`, Ruby 3.3          |
| skinny `~> 3.4.0`               | ✅ coexists, Ruby 3.4                    |
| skinny `~> 3.3.5` (same minor)  | ❌ 403 — duplicate Ruby 3.3             |
| fat `>= 3.2, < 4.1`             | ✅ classic `name-0.0.1-x86_64-linux`     |
| fat `>= 3.0` (2nd fat)          | ❌ 409 — repush not allowed             |

## Scope

This is the **server-side push acceptance + display** half of the proposal
(<https://gist.github.com/tenderlove/bd600206b3d7e163aa696e7d3b6c535d>).

Intentionally out of scope:

- The compact-index v2 `/v2/info` endpoint exposing `platform:` / `libc:`
  requirements.
- RubyGems / Bundler client changes to resolve and download content-addressed
  gems.