### PR TITLE
[Content Addressable] Part 2: Add content-addressable identity for skinny gems 

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -4,6 +4,7 @@ require "digest/sha2"
 
 class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   RUBYGEMS_IMPORT_DATE = Date.parse("2009-07-25")
+  DEFAULT_CONTENT_ADDRESS_LENGTH = 8
 
   self.ignored_columns += %w[info_checksum yanked_info_checksum]
 
@@ -52,6 +53,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     length: { minimum: 0, maximum: Gemcutter::MAX_TEXT_FIELD_LENGTH },
     allow_blank: true
   validates :sha256, :spec_sha256, format: { with: Patterns::BASE64_SHA256_PATTERN }, allow_nil: true
+  validates :sha256, presence: true, if: :content_addressable?
 
   validates :number, :platform, :gem_platform, :full_name, :gem_full_name, :canonical_number,
     name_format: { requires_letter: false },
@@ -459,6 +461,10 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   private
 
+  def content_addressable?
+    platformed? && ruby_abi.present?
+  end
+
   def set_ruby_abi
     self.ruby_abi = derive_ruby_abi
   end
@@ -517,15 +523,34 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def full_nameify!
     return if rubygem.nil?
-    self.full_name = "#{rubygem.name}-#{number}"
-    full_name << "-#{platform}" if platformed?
+    self.full_name = platform_identity(platform)
   end
 
   def gem_full_nameify!
     return if gem_platform.blank?
     return if rubygem.nil?
-    self.gem_full_name = "#{rubygem.name}-#{number}"
-    gem_full_name << "-#{gem_platform}" unless gem_platform == "ruby"
+
+    self.gem_full_name = platform_identity(gem_platform)
+  end
+
+  def content_address
+    digest = sha256_hex
+    raise ArgumentError, "Could not generate unique content-address" if digest.blank?
+
+    (DEFAULT_CONTENT_ADDRESS_LENGTH..digest.length).each do |length|
+      identity = "#{rubygem.name}-#{number}-#{digest.first(length)}"
+      return identity unless Version.where(full_name: identity).where.not(id: id).exists?
+    end
+
+    raise ArgumentError, "Could not generate unique content-address"
+  end
+
+  def platform_identity(platform_value)
+    return content_address if content_addressable? && sha256.present?
+
+    identity = "#{rubygem.name}-#{number}"
+    identity << "-#{platform_value}" unless platform_value == "ruby"
+    identity
   end
 
   def set_canonical_number

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -20,9 +20,9 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :attestations, dependent: :destroy, inverse_of: :version
 
   before_validation :set_canonical_number, if: :number_changed?
+  before_validation :set_ruby_abi, if: :required_ruby_version_changed?
   before_validation :full_nameify!
   before_validation :gem_full_nameify!
-  before_validation :set_ruby_abi, if: :required_ruby_version_changed?
   before_save :create_link_verifications, if: :metadata_changed?
   before_save :update_prerelease, if: :number_changed?
   # TODO: Remove this once we move to GemDownload only

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -570,6 +570,92 @@ class VersionTest < ActiveSupport::TestCase
       end
     end
 
+    context "with content-addressable naming" do
+      setup do
+        @rubygem = create(:rubygem, name: "nokogiri")
+      end
+
+      should "use platform identity for versions targeting multiple Ruby ABIs" do
+        version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "arm64-darwin-25",
+          gem_platform: "arm64-darwin-25",
+          required_ruby_version: ">= 3.2"
+        )
+
+        assert_equal("nokogiri-1.18.9-arm64-darwin-25", version.full_name)
+        assert_equal("nokogiri-1.18.9-arm64-darwin-25", version.gem_full_name)
+        assert_equal("#{version.full_name}.gem", version.gem_file_name)
+      end
+
+      should "use sha256 identity for versions targeting a single Ruby ABI" do
+        version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "arm64-darwin-25",
+          gem_platform: "arm64-darwin-25",
+          required_ruby_version: "~> 3.4.0",
+          sha256: Digest::SHA2.base64digest("skinny gem")
+        )
+
+        expected_identity = "nokogiri-1.18.9-#{version.sha256_hex.first(8)}"
+
+        assert_equal(expected_identity, version.full_name)
+        assert_equal(expected_identity, version.gem_full_name)
+        assert_equal("#{version.full_name}.gem", version.gem_file_name)
+      end
+
+      should "extend sha256 identity when another version already uses the first eight characters" do
+        shared_hex_prefix = "abc12345"
+        existing_sha256 = encoded_sha256_with_hex_prefix(shared_hex_prefix + ("0" * 56))
+        colliding_sha256 = encoded_sha256_with_hex_prefix(shared_hex_prefix + ("1" * 56))
+
+        existing_version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "arm64-darwin-25",
+          gem_platform: "arm64-darwin-25",
+          required_ruby_version: "~> 3.3.0",
+          sha256: existing_sha256
+        )
+
+        version = create(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "x86_64-darwin-25",
+          gem_platform: "x86_64-darwin-25",
+          required_ruby_version: "~> 3.4.0",
+          sha256: colliding_sha256
+        )
+
+        expected_identity = "nokogiri-1.18.9-#{version.sha256_hex.first(9)}"
+
+        assert_equal(expected_identity, version.full_name)
+        assert_equal(expected_identity, version.gem_full_name)
+        assert_not_equal(existing_version.full_name, version.full_name)
+      end
+
+      should "be invalid when content-addressable version has no sha256" do
+        version = build(
+          :version,
+          rubygem: @rubygem,
+          number: "1.18.9",
+          platform: "x86_64-darwin-25",
+          gem_platform: "x86_64-darwin-25",
+          required_ruby_version: "~> 3.4.0",
+          sha256: nil
+        )
+
+        refute_predicate version, :valid?
+        assert_includes version.errors[:sha256], "can't be blank"
+      end
+    end
+
     %w[x86_64-linux java mswin x86-mswin32-60].each do |platform|
       should "be able to find with platform of #{platform}" do
         version = create(:version, platform: platform)
@@ -1187,5 +1273,11 @@ class VersionTest < ActiveSupport::TestCase
         end
       end
     end
+  end
+
+  private
+
+  def encoded_sha256_with_hex_prefix(hex_sha256)
+    [[hex_sha256].pack("H*")].pack("m0")
   end
 end


### PR DESCRIPTION
### Changes:
- Adds content-addressable identity generation for skinny binary versions
- Updates `full_name` and `gem_full_name` generation so skinny binaries use a SHA-based identity while fat/source gems keep the existing platform-based identity.
- Extends SHA identity generation when the initial SHA prefix conflicts with an existing version. 

### Testing: 
Tests added to `version_test` to cover fat binary identity, skinny binary identity, SHA prefix collision handling.

To tophat:

Pull branch down and create or inspect a skinny binary version with a single Ruby ABI.

```
v = Version.create!(
    rubygem: Rubygem.find_by!(name: "example_gem"),
    number: "1.0.0",
    platform: "arm64-darwin-25",
    gem_platform: "arm64-darwin-25",
    required_ruby_version: "~> 3.4.0",
    sha256: Digest::SHA2.base64digest("skinny gem"),
    authors: ["Example"],
    built_at: Time.current,
    description: "Example skinny gem",
    indexed: true,
    licenses: ["MIT"],
    required_rubygems_version: ">= 2.6.3",
    requirements: "none",
    size: 1024
)

v.full_name
# => should look like "example_gem-1.0.0-<first-8-sha-chars>"

v.gem_file_name
# => should equal "#{v.full_name}.gem"
```