### PR TITLE
[Content Addressable] Part 3: Include Ruby ABI in uniqueness checks and duplicate detection

### DIFF
--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -129,13 +129,16 @@ class Pusher
         pusher_api_key: api_key
       )
 
+    version.required_ruby_version = spec.required_ruby_version.to_s
+    version.ruby_abi = Version.ruby_abi_for(version.required_ruby_version)
+
     unless @rubygem.new_record?
       # Return success for idempotent pushes
       return notify("Gem was already pushed: #{version.to_title}", 200) if version.indexed?
 
       # If the gem is yanked, we can't repush it
       # Additionally, we don't allow overwriting existing versions
-      if (existing = @rubygem.versions.find_by(number: version.number, platform: version.platform))
+      if (existing = @rubygem.versions.find_by(number: version.number, platform: version.platform, ruby_abi: version.ruby_abi))
         return republish_notification(existing)
       end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -459,17 +459,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     "#{full_name}.gem"
   end
 
-  private
-
-  def content_addressable?
-    platformed? && ruby_abi.present?
-  end
-
-  def set_ruby_abi
-    self.ruby_abi = derive_ruby_abi
-  end
-
-  def derive_ruby_abi
+  def self.ruby_abi_for(required_ruby_version)
     return if required_ruby_version.blank?
 
     requirement = Gem::Requirement.create(required_ruby_version.split(/\s*,\s*/))
@@ -492,19 +482,42 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     nil
   end
 
+  private
+
+  def content_addressable?
+    platformed? && ruby_abi.present?
+  end
+
+  def set_ruby_abi
+    self.ruby_abi = Version.ruby_abi_for(required_ruby_version)
+  end
+
   def update_prerelease
     self[:prerelease] = prerelease
   end
 
   def platform_and_number_are_unique
-    return unless Version.exists?(rubygem_id: rubygem_id, number: number, platform: platform)
-    errors.add(:base, "A version already exists with this number or platform.")
+    return unless Version.exists?(rubygem_id: rubygem_id, number: number, platform: platform, ruby_abi: ruby_abi)
+
+    message = if ruby_abi.present?
+                "A version already exists with this number, platform and Ruby ABI."
+              else
+                "A version already exists with this number or platform."
+              end
+
+    errors.add(:base, message)
   end
 
   def gem_platform_and_number_are_unique
-    platforms = Version.where(rubygem_id: rubygem_id, number: number, gem_platform: gem_platform).pluck(:platform)
+    platforms = Version.where(rubygem_id: rubygem_id, number: number, gem_platform: gem_platform, ruby_abi: ruby_abi).pluck(:platform)
     return if platforms.empty?
-    errors.add(:base, "A version already exists with this number and resolved platform #{platforms}")
+
+    message = if ruby_abi.present?
+                "A version already exists with this number, Ruby ABI and resolved platform #{platforms}"
+              else
+                "A version already exists with this number and resolved platform #{platforms}"
+              end
+    errors.add(:base, message)
   end
 
   def original_platform_resolves_to_gem_platform
@@ -585,7 +598,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def unique_canonical_number
-    version = Version.find_by(canonical_number: canonical_number, rubygem_id: rubygem_id, platform: platform)
+    version = Version.find_by(canonical_number: canonical_number, rubygem_id: rubygem_id, platform: platform, ruby_abi: ruby_abi)
     errors.add(:canonical_number, "has already been taken. Existing version: #{version.number}") unless version.nil?
   end
 

--- a/db/migrate/20260701131420_add_ruby_abi_to_version_unique_indexes.rb
+++ b/db/migrate/20260701131420_add_ruby_abi_to_version_unique_indexes.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class AddRubyAbiToVersionUniqueIndexes < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :versions,
+      %i[canonical_number rubygem_id platform ruby_abi],
+      unique: true,
+      where: "ruby_abi IS NOT NULL",
+      name: "index_versions_canonical_platform_abi",
+      algorithm: :concurrently
+
+    add_index :versions,
+      %i[canonical_number rubygem_id platform],
+      unique: true,
+      where: "ruby_abi IS NULL",
+      name: "index_versions_canonical_platform_no_abi",
+      algorithm: :concurrently
+
+    add_index :versions,
+      %i[rubygem_id number platform ruby_abi],
+      unique: true,
+      where: "ruby_abi IS NOT NULL",
+      name: "index_versions_number_platform_abi",
+      algorithm: :concurrently
+
+    add_index :versions,
+      %i[rubygem_id number platform],
+      unique: true,
+      where: "ruby_abi IS NULL",
+      name: "index_versions_number_platform_no_abi",
+      algorithm: :concurrently
+  end
+
+  def down
+    remove_index :versions,
+      name: "index_versions_canonical_platform_abi",
+      algorithm: :concurrently
+
+    remove_index :versions,
+      name: "index_versions_canonical_platform_no_abi",
+      algorithm: :concurrently
+
+    remove_index :versions,
+      name: "index_versions_number_platform_abi",
+      algorithm: :concurrently
+
+    remove_index :versions,
+      name: "index_versions_number_platform_no_abi",
+      algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260706100000_remove_old_version_unique_indexes.rb
+++ b/db/migrate/20260706100000_remove_old_version_unique_indexes.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class RemoveOldVersionUniqueIndexes < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :versions,
+      name: "index_versions_on_canonical_number_and_rubygem_id_and_platform",
+      algorithm: :concurrently
+
+    remove_index :versions,
+      name: "index_versions_on_rubygem_id_and_number_and_platform",
+      algorithm: :concurrently
+  end
+
+  def down
+    add_index :versions,
+      %i[canonical_number rubygem_id platform],
+      unique: true,
+      name: "index_versions_on_canonical_number_and_rubygem_id_and_platform",
+      algorithm: :concurrently
+
+    add_index :versions,
+      %i[rubygem_id number platform],
+      unique: true,
+      name: "index_versions_on_rubygem_id_and_number_and_platform",
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_01_131420) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_06_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -728,7 +728,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_01_131420) do
     t.index "lower((gem_full_name)::text)", name: "index_versions_on_lower_gem_full_name"
     t.index ["built_at"], name: "index_versions_on_built_at"
     t.index ["canonical_number", "rubygem_id", "platform", "ruby_abi"], name: "index_versions_canonical_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
-    t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_on_canonical_number_and_rubygem_id_and_platform", unique: true
     t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_canonical_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
     t.index ["created_at"], name: "index_versions_on_created_at"
     t.index ["full_name"], name: "index_versions_on_full_name"
@@ -739,7 +738,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_01_131420) do
     t.index ["pusher_api_key_id"], name: "index_versions_on_pusher_api_key_id"
     t.index ["pusher_id"], name: "index_versions_on_pusher_id"
     t.index ["rubygem_id", "number", "platform", "ruby_abi"], name: "index_versions_number_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
-    t.index ["rubygem_id", "number", "platform"], name: "index_versions_on_rubygem_id_and_number_and_platform", unique: true
     t.index ["rubygem_id", "number", "platform"], name: "index_versions_number_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
     t.index ["rubygem_id", "position", "created_at"], name: "index_versions_on_rubygem_id_and_position_and_created_at", order: { created_at: :desc }, where: "(indexed = true)", include: ["full_name", "number", "platform"]
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_29_112747) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_01_131420) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -727,7 +727,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_112747) do
     t.index "lower((full_name)::text)", name: "index_versions_on_lower_full_name"
     t.index "lower((gem_full_name)::text)", name: "index_versions_on_lower_gem_full_name"
     t.index ["built_at"], name: "index_versions_on_built_at"
+    t.index ["canonical_number", "rubygem_id", "platform", "ruby_abi"], name: "index_versions_canonical_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
     t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_on_canonical_number_and_rubygem_id_and_platform", unique: true
+    t.index ["canonical_number", "rubygem_id", "platform"], name: "index_versions_canonical_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
     t.index ["created_at"], name: "index_versions_on_created_at"
     t.index ["full_name"], name: "index_versions_on_full_name"
     t.index ["indexed", "yanked_at"], name: "index_versions_on_indexed_and_yanked_at"
@@ -736,7 +738,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_29_112747) do
     t.index ["prerelease"], name: "index_versions_on_prerelease"
     t.index ["pusher_api_key_id"], name: "index_versions_on_pusher_api_key_id"
     t.index ["pusher_id"], name: "index_versions_on_pusher_id"
+    t.index ["rubygem_id", "number", "platform", "ruby_abi"], name: "index_versions_number_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
     t.index ["rubygem_id", "number", "platform"], name: "index_versions_on_rubygem_id_and_number_and_platform", unique: true
+    t.index ["rubygem_id", "number", "platform"], name: "index_versions_number_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
     t.index ["rubygem_id", "position", "created_at"], name: "index_versions_on_rubygem_id_and_position_and_created_at", order: { created_at: :desc }, where: "(indexed = true)", include: ["full_name", "number", "platform"]
   end
 

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -149,6 +149,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.expects(:original_platform).returns "ruby"
       spec.expects(:platform).returns "ruby"
       spec.expects(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.default
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
       @cutter.stubs(:size).returns 5
@@ -193,6 +194,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:original_platform).returns "ruby"
       spec.stubs(:platform).returns "ruby"
       spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.default
       spec.stubs(:metadata).returns({})
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
@@ -214,6 +216,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.expects(:platform).returns "ruby"
       spec.expects(:original_platform).returns "ruby"
       spec.expects(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.default
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
 
@@ -233,6 +236,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:original_platform).returns "ruby"
       spec.stubs(:platform).returns "ruby"
       spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.default
       spec.stubs(:metadata).returns({})
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
@@ -255,6 +259,7 @@ class PusherTest < ActiveSupport::TestCase
       spec.stubs(:original_platform).returns "universal-darwin-6000"
       spec.stubs(:platform).returns Gem::Platform.new("universal-darwin-6000")
       spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.default
       @cutter.stubs(:spec).returns spec
       @cutter.stubs(:spec_contents).returns "spec"
 
@@ -265,6 +270,60 @@ class PusherTest < ActiveSupport::TestCase
 
       assert_equal "universal-darwin-6000", @cutter.version.platform
       assert_equal "universal-darwin-6000", @cutter.version.gem_platform
+    end
+
+    should "initialize a new version when the existing version has a different Ruby ABI" do
+      rubygem = create(:rubygem, name: "sandworm")
+      create(:version, rubygem: rubygem, number: "1.0.0", platform: "arm64-darwin-25",
+      required_ruby_version: "~> 3.3.0")
+
+      spec = mock
+      spec.stubs(:name).returns "sandworm"
+      spec.stubs(:version).returns Gem::Version.new("1.0.0")
+      spec.stubs(:original_platform).returns "arm64-darwin-25"
+      spec.stubs(:platform).returns Gem::Platform.new("arm64-darwin-25")
+      spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.new("~> 3.4.0")
+      spec.stubs(:metadata).returns({})
+
+      @cutter.stubs(:spec).returns spec
+      @cutter.stubs(:spec_contents).returns "spec"
+      @cutter.stubs(:size).returns 5
+      @cutter.stubs(:body).returns StringIO.new("dummy body")
+
+      assert @cutter.find
+
+      assert_equal rubygem, @cutter.rubygem
+      assert_not_predicate @cutter.version, :persisted?
+      assert_equal "1.0.0", @cutter.version.number
+      assert_equal "arm64-darwin-25", @cutter.version.platform
+      assert_equal "~> 3.4.0", @cutter.version.required_ruby_version
+      assert_equal "3.4", @cutter.version.ruby_abi
+    end
+
+    should "reject a new version when the existing version has the same Ruby ABI" do
+      rubygem = create(:rubygem, name: "sandworm")
+      create(:version, rubygem: rubygem, number: "1.0.0", platform: "arm64-darwin-25",
+      required_ruby_version: "~> 3.4.0")
+
+      spec = mock
+      spec.stubs(:name).returns "sandworm"
+      spec.stubs(:version).returns Gem::Version.new("1.0.0")
+      spec.stubs(:original_platform).returns "arm64-darwin-25"
+      spec.stubs(:platform).returns Gem::Platform.new("arm64-darwin-25")
+      spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.new("~> 3.4.0")
+      spec.stubs(:metadata).returns({})
+
+      @cutter.stubs(:spec).returns spec
+      @cutter.stubs(:spec_contents).returns "spec"
+      @cutter.stubs(:size).returns 5
+      @cutter.stubs(:body).returns StringIO.new("dummy body")
+
+      refute @cutter.find
+
+      assert_equal 409, @cutter.code
+      assert_match(/Repushing of gem versions is not allowed/, @cutter.message)
     end
   end
 

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -159,6 +159,73 @@ class VersionTest < ActiveSupport::TestCase
       refute_predicate @dup_version, :valid?
     end
 
+    should "allow duplicate versions with different Ruby ABIs" do
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+
+      version = build(:version, rubygem: @rubygem, number: existing_version.number, platform: existing_version.platform,
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0")
+
+      assert_predicate version, :valid?
+    end
+
+    should "not allow duplicate versions with the same Ruby ABI" do
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+
+      version = build(:version, rubygem: @rubygem, number: existing_version.number, platform: existing_version.platform,
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0")
+
+      refute_predicate version, :valid?
+
+      assert_raises ActiveRecord::RecordNotUnique do
+        version.save!(validate: false)
+      end
+    end
+
+    should "not allow duplicate versions with nil Ruby ABIs" do
+      create(
+        :version,
+        rubygem: @rubygem,
+        number: "1.0.0",
+        platform: "arm64-darwin-25",
+        gem_platform: "arm64-darwin-25",
+        required_ruby_version: ">= 3.2"
+      )
+
+      duplicate = build(
+        :version,
+        rubygem: @rubygem,
+        number: "1.0.0",
+        platform: "arm64-darwin-25",
+        gem_platform: "arm64-darwin-25",
+        required_ruby_version: ">= 3.0"
+      )
+
+      refute_predicate duplicate, :valid?
+      assert_nil duplicate.ruby_abi
+
+      assert_raises ActiveRecord::RecordNotUnique do
+        duplicate.save!(validate: false)
+      end
+    end
+
+    should "allow canonical number duplicates with different Ruby ABIs" do
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+
+      version = build(:version, rubygem: @rubygem, number: "1.0", platform: existing_version.platform,
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0")
+
+      assert_predicate version, :valid?
+    end
+
+    should "not allow canonical number duplicates with the same Ruby ABI" do
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+
+      version = build(:version, rubygem: @rubygem, number: "1.0", platform: existing_version.platform,
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0")
+
+      refute_predicate version, :valid?
+    end
+
     should "be able to find dependencies" do
       @dependency = create(:rubygem)
       @version = build(:version, rubygem: @rubygem, number: "1.0.0", platform: "ruby")


### PR DESCRIPTION
### Changes:
- Updates Version uniqueness checks to include ruby_abi when comparing duplicate versions.
- Updates the push-path duplicate lookup so skinny binaries with different Ruby ABIs can coexist, while same-ABI
  duplicates are still rejected.
- Replaces the existing Version unique indexes with partial unique indexes that preserve old fat/source gem uniqueness
  when ruby_abi is NULL, and include ruby_abi for skinny gems.
- Updates schema for the new indexes.

  ### Testing:
- Tests added to version_test for duplicate version and canonical version behavior with same/different Ruby ABIs.
- Tests added to pusher_test for push duplicate detection with same/different Ruby ABIs.
- Patch `models/pusher_test` to stub `required_ruby_version` so that the new validations don't cause test failures.

To tophat:

Pull branch down, ensure migrations have been run.

```
rubygem = Rubygem.find_or_create_by!(name: "skinny-tophat-different-abi")

v1 = rubygem.versions.create!(
  number: "1.0.0",
  platform: "arm64-darwin-25",
  gem_platform: "arm64-darwin-25",
  required_ruby_version: "~> 3.3.0",
  summary: "test",
  authors: ["test"],
  sha256: Digest::SHA2.base64digest("skinny-tophat-different-abi-3.3")
)

v2 = rubygem.versions.create!(
  number: "1.0.0",
  platform: "arm64-darwin-25",
  gem_platform: "arm64-darwin-25",
  required_ruby_version: "~> 3.4.0",
  summary: "test",
  authors: ["test"],
  sha256: Digest::SHA2.base64digest("skinny-tophat-different-abi-3.4")
)

[v1.ruby_abi, v2.ruby_abi]
# => ["3.3", "3.4"]

# Duplicate same-ABI skinny version should be invalid:

dup_skinny = rubygem.versions.build(
  number: "1.0.0",
  platform: "arm64-darwin-25",
  gem_platform: "arm64-darwin-25",
  required_ruby_version: "~> 3.4.0",
  summary: "test",
  authors: ["test"],
  sha256: Digest::SHA2.base64digest("skinny-tophat-different-abi-3.4-dup")
)

dup_skinny.valid?
# => false

# Fat binaries without Ruby ABIs still follow the old uniqueness behaviour.
```