### PR TITLE
[Content Addressable] Part 4: Gate skinny gem pushes behind a feature branch

### DIFF
--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -2,6 +2,7 @@
 
 class FeatureFlag
   ORGANIZATIONS = :organizations
+  CONTENT_ADDRESSABLE_GEM_PUSHES = :content_addressable_gem_pushes
 
   class << self
     def enabled?(flag_name, actor = nil)

--- a/app/models/pusher.rb
+++ b/app/models/pusher.rb
@@ -4,6 +4,8 @@ require "digest/sha2"
 require "gem_validator"
 
 class Pusher
+  CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION = ">= 4.1.0.dev"
+
   include TraceTagger
   include SemanticLogger::Loggable
 
@@ -60,7 +62,7 @@ class Pusher
 
     return notify("There was a problem saving your gem: #{rubygem.all_errors(version)}", 403) unless rubygem.valid? && version.valid?
 
-    unless version.full_name == spec.original_name && version.gem_full_name == spec.full_name
+    unless uploaded_spec_matches_version?
       return notify("There was a problem saving your gem: the uploaded spec has malformed platform attributes", 409)
     end
 
@@ -130,8 +132,7 @@ class Pusher
       )
 
     version.required_ruby_version = spec.required_ruby_version.to_s
-    version.ruby_abi = Version.ruby_abi_for(version.required_ruby_version)
-
+    version.ruby_abi = Version.ruby_abi_for(version.required_ruby_version) if FeatureFlag.enabled?(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, owner)
     unless @rubygem.new_record?
       # Return success for idempotent pushes
       return notify("Gem was already pushed: #{version.to_title}", 200) if version.indexed?
@@ -204,6 +205,35 @@ class Pusher
 
   private
 
+  def uploaded_spec_matches_version?
+    return version.full_name == spec.original_name && version.gem_full_name == spec.full_name unless version.content_addressable?
+
+    version.platform == spec.original_platform.to_s && version.gem_platform == spec.platform.to_s
+  end
+
+  def required_rubygems_version_satisfies_content_addressable_floor?
+    requirements = version.required_rubygems_version.presence&.split(/\s*,\s*/) || [">= 0"]
+    requirement = Gem::Requirement.new(requirements)
+
+    requirement.requirements.any? do |operator, required_version|
+      case operator
+      when ">=", "~>", "=", ">"
+        Gem::Requirement.new(CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION).satisfied_by?(required_version)
+      else
+        false
+      end
+    end
+  rescue Gem::Requirement::BadRequirementError
+    false
+  end
+
+  def normalize_content_addressable_gem_metadata!
+    return unless version.content_addressable?
+    return if required_rubygems_version_satisfies_content_addressable_floor?
+
+    version.update!(required_rubygems_version: CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION)
+  end
+
   def after_write
     GemCachePurger.call(rubygem.name)
     RackAttackReset.gem_push_backoff(@request.remote_ip, owner.to_gid) if @request&.remote_ip.present?
@@ -223,6 +253,7 @@ class Pusher
   def update
     rubygem.disown if rubygem.versions.indexed.none?
     rubygem.update_attributes_from_gem_specification!(version, spec)
+    normalize_content_addressable_gem_metadata!
 
     if rubygem.unowned?
       if api_key.user?

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -21,7 +21,6 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :attestations, dependent: :destroy, inverse_of: :version
 
   before_validation :set_canonical_number, if: :number_changed?
-  before_validation :set_ruby_abi, if: :required_ruby_version_changed?
   before_validation :full_nameify!
   before_validation :gem_full_nameify!
   before_save :create_link_verifications, if: :metadata_changed?
@@ -383,7 +382,9 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def to_title
-    if platformed?
+    if content_addressable?
+      "#{rubygem.name} (#{number}-#{content_address}, Platform: #{platform}, Ruby ABI #{ruby_abi})"
+    elsif platformed?
       "#{rubygem.name} (#{number}-#{platform})"
     else
       "#{rubygem.name} (#{number})"
@@ -482,15 +483,11 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     nil
   end
 
-  private
-
   def content_addressable?
     platformed? && ruby_abi.present?
   end
 
-  def set_ruby_abi
-    self.ruby_abi = Version.ruby_abi_for(required_ruby_version)
-  end
+  private
 
   def update_prerelease
     self[:prerelease] = prerelease
@@ -551,15 +548,20 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     raise ArgumentError, "Could not generate unique content-address" if digest.blank?
 
     (DEFAULT_CONTENT_ADDRESS_LENGTH..digest.length).each do |length|
-      identity = "#{rubygem.name}-#{number}-#{digest.first(length)}"
-      return identity unless Version.where(full_name: identity).where.not(id: id).exists?
+      candidate = digest.first(length)
+      identity = "#{rubygem.name}-#{number}-#{candidate}"
+      return candidate unless Version.where(full_name: identity).where.not(id: id).exists?
     end
 
     raise ArgumentError, "Could not generate unique content-address"
   end
 
+  def content_addressed_full_name
+    "#{rubygem.name}-#{number}-#{content_address}"
+  end
+
   def platform_identity(platform_value)
-    return content_address if content_addressable? && sha256.present?
+    return content_addressed_full_name if content_addressable? && sha256.present?
 
     identity = "#{rubygem.name}-#{number}"
     identity << "-#{platform_value}" unless platform_value == "ruby"

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -4,6 +4,9 @@
   <% if version.platformed? %>
     <span class="gem__version__date platform"><%= version.platform %></span>
   <% end %>
+  <% if version.ruby_abi.present? %>
+    <span class="gem__version__date ruby-abi">Ruby ABI <%= version.ruby_abi %></span>
+  <% end %>
 
   <span class="gem__version__date">(<%= number_to_human_size(version.size) %>)</span>
   <% if version.yanked? -%>

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -104,7 +104,8 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
       required_ruby_version: "~> 3.2.0",
       required_rubygems_version: ">= 4.1.0.dev",
       sha256: Digest::SHA2.base64digest("v2rubyabi-2.9.0-x86_64-linux-musl"),
-      created_at: Time.utc(2026, 5, 1, 12, 0, 0)
+      created_at: Time.utc(2026, 5, 1, 12, 0, 0),
+      ruby_abi: "3.2"
     )
 
     content_address = version.full_name.split("-").last
@@ -208,7 +209,8 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
       required_ruby_version: "~> 3.2.0",
       required_rubygems_version: ">= 4.1.0.dev",
       sha256: Digest::SHA2.base64digest("v2rubyabi-2.9.0-x86_64-linux-musl"),
-      created_at: Time.utc(2026, 5, 1, 12, 0, 0)
+      created_at: Time.utc(2026, 5, 1, 12, 0, 0),
+      ruby_abi: "3.2"
     )
 
     content_address = version.full_name.split("-").last

--- a/test/integration/pusher_test.rb
+++ b/test/integration/pusher_test.rb
@@ -392,6 +392,10 @@ class PusherIntegrationTest < ActiveSupport::TestCase
           version_gid: @rubygem.versions.last.to_gid.to_s
         }, @rubygem.events.where(tag: Events::RubygemEvent::VERSION_PUSHED).sole
       end
+
+      should "set success message" do
+        assert_equal "Successfully registered gem: #{@cutter.version.to_title}", @cutter.message
+      end
     end
 
     should "purge gem cache" do
@@ -430,6 +434,109 @@ class PusherIntegrationTest < ActiveSupport::TestCase
           end
         end
       end
+    end
+
+    should "preserve required rubygems version for gems supporting multiple Ruby ABIs" do
+      @cutter.version.update!(required_rubygems_version: ">= 3.0", ruby_abi: nil)
+
+      assert @cutter.save
+
+      assert_equal ">= 3.0", @cutter.version.reload.required_rubygems_version
+    end
+  end
+
+  context "successfully saving a gemcutter scoped to one Ruby ABI" do
+    setup do
+      @rubygem = create(:rubygem, name: "sandworm")
+      @version = create(
+        :version,
+        rubygem: @rubygem,
+        number: "1.0.0",
+        platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.4.0",
+        required_rubygems_version: ">= 0",
+        ruby_abi: "3.4",
+        sha256: Digest::SHA2.base64digest("sandworm-1.0.0-arm64-darwin-25-3.4"),
+        pusher_api_key: @cutter.api_key
+      )
+
+      @cutter.stubs(:rubygem).returns @rubygem
+      @cutter.stubs(:version).returns @version
+      @cutter.stubs(:spec).returns(mock)
+      @rubygem.stubs(:update_attributes_from_gem_specification!)
+      GemCachePurger.stubs(:call)
+      @cutter.stubs(:write_gem)
+    end
+
+    should "set content addressable required rubygems version floor" do
+      assert @cutter.save
+
+      assert_equal Pusher::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, @version.reload.required_rubygems_version
+    end
+
+    should "preserve required rubygems version when it is higher than the content addressable floor" do
+      @version.update!(required_rubygems_version: ">= 5.0.0")
+
+      assert @cutter.save
+
+      assert_equal ">= 5.0.0", @version.reload.required_rubygems_version
+    end
+
+    should "preserve compound required rubygems version when its lower bound satisfies the content addressable floor" do
+      @version.update!(required_rubygems_version: ">= 4.2, < 5")
+
+      assert @cutter.save
+
+      assert_equal ">= 4.2, < 5", @version.reload.required_rubygems_version
+    end
+
+    should "set content addressable required rubygems version floor when requirement only has an upper bound and value is greater" do
+      @version.update!(required_rubygems_version: "< 5")
+
+      assert @cutter.save
+
+      assert_equal Pusher::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION, @version.reload.required_rubygems_version
+    end
+
+    should "preserve required rubygems version when requirement only has an = operator and value is greater than CA value" do
+      @version.update!(required_rubygems_version: "= 4.2")
+
+      assert @cutter.save
+
+      assert_equal "= 4.2", @version.reload.required_rubygems_version
+    end
+
+    should "preserve required rubygems version when requirement only has a ~> operator and value is greater" do
+      @version.update!(required_rubygems_version: "~> 4.2")
+
+      assert @cutter.save
+
+      assert_equal "~> 4.2", @version.reload.required_rubygems_version
+    end
+
+    should "normalize content addressable required rubygems version after applying gemspec metadata" do
+      sequence = sequence("content addressable metadata normalization")
+
+      @rubygem
+        .expects(:update_attributes_from_gem_specification!)
+        .with(@version, @cutter.spec)
+        .in_sequence(sequence)
+
+      @version
+        .expects(:update!)
+        .with(required_rubygems_version: Pusher::CONTENT_ADDRESSABLE_REQUIRED_RUBYGEMS_VERSION)
+        .in_sequence(sequence)
+        .returns(true)
+
+      AfterVersionWriteJob.any_instance.stubs(:perform)
+
+      assert @cutter.save
+    end
+
+    should "include platform and Ruby ABI in success message" do
+      assert @cutter.save
+
+      assert_equal "Successfully registered gem: #{@version.to_title}", @cutter.message
     end
   end
 

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -44,7 +44,8 @@ class GemInfoTest < ActiveSupport::TestCase
         gem_platform: "x86_64-linux-musl",
         required_ruby_version: "~> 3.2.0",
         sha256: Digest::SHA2.base64digest("single-abi-2.9.0-x86_64-linux-musl"),
-        info_checksum_v2: "single-abi-info-checksum"
+        info_checksum_v2: "single-abi-info-checksum",
+        ruby_abi: "3.2"
       )
 
       info = GemInfo.new("single-abi-info").compact_index_info
@@ -163,7 +164,8 @@ class GemInfoTest < ActiveSupport::TestCase
         required_ruby_version: "~> 3.2.0",
         sha256: Digest::SHA2.base64digest("skinny-2.9.0-x86_64-linux-musl"),
         created_at: 2.days.ago,
-        info_checksum_v2: "skinny-info"
+        info_checksum_v2: "skinny-info",
+        ruby_abi: "3.2"
       )
 
       versions = GemInfo.compact_index_versions(3.days.ago)
@@ -221,7 +223,8 @@ class GemInfoTest < ActiveSupport::TestCase
         required_ruby_version: "~> 3.2.0",
         sha256: Digest::SHA2.base64digest("skinny-public-2.9.0-x86_64-linux-musl"),
         created_at: @ts,
-        info_checksum_v2: "skinny-public-info"
+        info_checksum_v2: "skinny-public-info",
+        ruby_abi: "3.2"
       )
 
       versions = GemInfo.compact_index_public_versions(@ts)

--- a/test/models/pusher_test.rb
+++ b/test/models/pusher_test.rb
@@ -272,10 +272,38 @@ class PusherTest < ActiveSupport::TestCase
       assert_equal "universal-darwin-6000", @cutter.version.gem_platform
     end
 
-    should "initialize a new version when the existing version has a different Ruby ABI" do
+    should "initialize a new version but not set the Ruby ABI when the feature flag is off" do
+      rubygem = create(:rubygem, name: "sandworm")
+
+      spec = mock
+      spec.stubs(:name).returns "sandworm"
+      spec.stubs(:version).returns Gem::Version.new("1.0.0")
+      spec.stubs(:original_platform).returns "arm64-darwin-25"
+      spec.stubs(:platform).returns Gem::Platform.new("arm64-darwin-25")
+      spec.stubs(:cert_chain).returns nil
+      spec.stubs(:required_ruby_version).returns Gem::Requirement.new("~> 3.4.0")
+      spec.stubs(:metadata).returns({})
+
+      @cutter.stubs(:spec).returns spec
+      @cutter.stubs(:spec_contents).returns "spec"
+      @cutter.stubs(:size).returns 5
+      @cutter.stubs(:body).returns StringIO.new("dummy body")
+
+      assert @cutter.find
+
+      assert_equal rubygem, @cutter.rubygem
+      assert_not_predicate @cutter.version, :persisted?
+      assert_equal "1.0.0", @cutter.version.number
+      assert_equal "arm64-darwin-25", @cutter.version.platform
+      assert_equal "~> 3.4.0", @cutter.version.required_ruby_version
+      assert_nil @cutter.version.ruby_abi
+    end
+
+    should "set Ruby ABI for a new version when the feature flag is on" do
+      FeatureFlag.enable_for_actor(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, @user)
       rubygem = create(:rubygem, name: "sandworm")
       create(:version, rubygem: rubygem, number: "1.0.0", platform: "arm64-darwin-25",
-      required_ruby_version: "~> 3.3.0")
+        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       spec = mock
       spec.stubs(:name).returns "sandworm"
@@ -302,9 +330,10 @@ class PusherTest < ActiveSupport::TestCase
     end
 
     should "reject a new version when the existing version has the same Ruby ABI" do
+      FeatureFlag.enable_for_actor(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, @user)
       rubygem = create(:rubygem, name: "sandworm")
       create(:version, rubygem: rubygem, number: "1.0.0", platform: "arm64-darwin-25",
-      required_ruby_version: "~> 3.4.0")
+        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4")
 
       spec = mock
       spec.stubs(:name).returns "sandworm"
@@ -324,6 +353,33 @@ class PusherTest < ActiveSupport::TestCase
 
       assert_equal 409, @cutter.code
       assert_match(/Repushing of gem versions is not allowed/, @cutter.message)
+    end
+  end
+
+  context "validating uploaded spec platform attributes" do
+    should "allow content-addressable versions whose uploaded spec keeps platform identity" do
+      rubygem = create(:rubygem, name: "sandworm")
+      version = create(
+        :version,
+        rubygem: rubygem,
+        number: "1.0.0",
+        platform: "arm64-darwin-25",
+        gem_platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.4.0",
+        ruby_abi: "3.4",
+        sha256: Digest::SHA2.base64digest("sandworm-1.0.0-arm64-darwin-25-3.4")
+      )
+      spec = mock
+      spec.stubs(:cert_chain).returns([])
+      spec.stubs(:original_platform).returns("arm64-darwin-25")
+      spec.stubs(:platform).returns Gem::Platform.new("arm64-darwin-25")
+
+      @cutter.stubs(:rubygem).returns rubygem
+      @cutter.stubs(:version).returns version
+      @cutter.instance_variable_set(:@spec, spec)
+
+      assert_predicate version, :content_addressable?
+      assert @cutter.validate
     end
   end
 

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -160,19 +160,21 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "allow duplicate versions with different Ruby ABIs" do
-      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       version = build(:version, rubygem: @rubygem, number: existing_version.number, platform: existing_version.platform,
-        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0")
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0", ruby_abi: "3.4")
 
       assert_predicate version, :valid?
     end
 
     should "not allow duplicate versions with the same Ruby ABI" do
-      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       version = build(:version, rubygem: @rubygem, number: existing_version.number, platform: existing_version.platform,
-        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0")
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       refute_predicate version, :valid?
 
@@ -209,19 +211,21 @@ class VersionTest < ActiveSupport::TestCase
     end
 
     should "allow canonical number duplicates with different Ruby ABIs" do
-      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       version = build(:version, rubygem: @rubygem, number: "1.0", platform: existing_version.platform,
-        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0")
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.4.0", ruby_abi: "3.4")
 
       assert_predicate version, :valid?
     end
 
     should "not allow canonical number duplicates with the same Ruby ABI" do
-      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25", required_ruby_version: "~> 3.3.0")
+      existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       version = build(:version, rubygem: @rubygem, number: "1.0", platform: existing_version.platform,
-        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0")
+        gem_platform: existing_version.gem_platform, required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")
 
       refute_predicate version, :valid?
     end
@@ -552,74 +556,37 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal "abc-1.1.1.gem", @version.gem_file_name
     end
 
-    context "deriving ruby ABI" do
-      should "set ruby_abi when required_ruby_version targets a single Ruby minor version" do
-        version = create(:version, required_ruby_version: "~> 3.2.0")
-
-        assert_equal("3.2", version.ruby_abi)
+    context ".ruby_abi_for" do
+      should "returns Ruby ABI when required_ruby_version targets a single Ruby minor version" do
+        assert_equal "3.2", Version.ruby_abi_for("~> 3.2.0")
       end
 
-      should "not set ruby_abi when required_ruby_version is broad" do
-        version = create(:version, required_ruby_version: ">= 3.2")
-
-        assert_nil(version.ruby_abi)
+      should "return nil when required_ruby_version is broad" do
+        assert_nil Version.ruby_abi_for(">= 3.2")
       end
 
-      should "only set ruby_abi for clean three-segment requirements" do
-        version = create(:version, required_ruby_version: "~> 3.2.0.0")
-
-        assert_nil(version.ruby_abi)
+      should "return nil for clean requirements with more than three segments" do
+        assert_nil Version.ruby_abi_for("~> 3.2.0.0")
       end
 
-      should "not set ruby_abi when required_ruby_version has multiple requirements" do
-        version = create(:version, required_ruby_version: ">= 3.2, < 3.4")
-
-        assert_nil(version.ruby_abi)
+      should "return nil when required_ruby_version has multiple requirements" do
+        assert_nil Version.ruby_abi_for(">= 3.2, < 3.4")
       end
 
-      should "not set ruby_abi when required_ruby_version is malformed" do
-        version = build(:version, required_ruby_version: "not a requirement")
-
-        assert_nothing_raised { version.valid? }
-        assert_nil(version.ruby_abi)
-        assert_includes(version.errors[:required_ruby_version], "must be list of valid requirements")
+      should "return nil when required_ruby_version is malformed" do
+        assert_nil Version.ruby_abi_for("not a requirement")
       end
 
-      should "not set ruby_abi when required_ruby_version indicates multiple Ruby ABIs" do
-        version = create(:version, required_ruby_version: "~> 3.2")
-
-        assert_nil(version.ruby_abi)
+      should "return nil when required_ruby_version indicates multiple Ruby ABIs" do
+        assert_nil Version.ruby_abi_for("~> 3.2")
       end
 
-      should "not set ruby_abi when required_ruby_version is blank" do
-        version = create(:version, required_ruby_version: "")
-
-        assert_nil(version.ruby_abi)
+      should "return nil when required_ruby_version is blank" do
+        assert_nil Version.ruby_abi_for("")
       end
 
-      should "not set ruby_abi for patch-specific pessimistic requirements" do
-        version = create(:version, required_ruby_version: "~> 3.2.1")
-
-        assert_nil(version.ruby_abi)
-      end
-
-      should "recalculate ruby_abi when required_ruby_version is updated" do
-        version = create(:version, required_ruby_version: ">= 3.2.0")
-
-        assert_nil(version.ruby_abi)
-
-        version.update!(required_ruby_version: "~> 3.2.0")
-
-        assert_equal("3.2", version.reload.ruby_abi)
-      end
-
-      should "not recalculate ruby_abi when required_ruby_version is unchanged" do
-        version = create(:version, required_ruby_version: "~> 3.2.0")
-        version.update_column(:ruby_abi, "manually-set")
-
-        version.update!(summary: "Updated summary")
-
-        assert_equal("manually-set", version.reload.ruby_abi)
+      should "return nil for patch-specific pessimistic requirements" do
+        assert_nil Version.ruby_abi_for("~> 3.2.1")
       end
     end
 
@@ -658,15 +625,18 @@ class VersionTest < ActiveSupport::TestCase
       end
 
       should "use sha256 identity for versions targeting a single Ruby ABI" do
-        version = create(
+        version = build(
           :version,
           rubygem: @rubygem,
           number: "1.18.9",
           platform: "arm64-darwin-25",
           gem_platform: "arm64-darwin-25",
           required_ruby_version: "~> 3.4.0",
-          sha256: Digest::SHA2.base64digest("skinny gem")
+          ruby_abi: "3.4",
+          sha256: Digest::SHA2.base64digest("content addressable gem")
         )
+
+        version.save!
 
         expected_identity = "nokogiri-1.18.9-#{version.sha256_hex.first(8)}"
 
@@ -680,25 +650,29 @@ class VersionTest < ActiveSupport::TestCase
         existing_sha256 = encoded_sha256_with_hex_prefix(shared_hex_prefix + ("0" * 56))
         colliding_sha256 = encoded_sha256_with_hex_prefix(shared_hex_prefix + ("1" * 56))
 
-        existing_version = create(
+        existing_version = build(
           :version,
           rubygem: @rubygem,
           number: "1.18.9",
           platform: "arm64-darwin-25",
           gem_platform: "arm64-darwin-25",
           required_ruby_version: "~> 3.3.0",
-          sha256: existing_sha256
+          sha256: existing_sha256,
+          ruby_abi: "3.3"
         )
+        existing_version.save!
 
-        version = create(
+        version = build(
           :version,
           rubygem: @rubygem,
           number: "1.18.9",
           platform: "x86_64-darwin-25",
           gem_platform: "x86_64-darwin-25",
           required_ruby_version: "~> 3.4.0",
-          sha256: colliding_sha256
+          sha256: colliding_sha256,
+          ruby_abi: "3.4"
         )
+        version.save!
 
         expected_identity = "nokogiri-1.18.9-#{version.sha256_hex.first(9)}"
 
@@ -715,7 +689,8 @@ class VersionTest < ActiveSupport::TestCase
           platform: "x86_64-darwin-25",
           gem_platform: "x86_64-darwin-25",
           required_ruby_version: "~> 3.4.0",
-          sha256: nil
+          sha256: nil,
+          ruby_abi: "3.4"
         )
 
         refute_predicate version, :valid?
@@ -844,6 +819,23 @@ class VersionTest < ActiveSupport::TestCase
       @version.platform = "zomg"
 
       assert_equal "#{@version.rubygem.name} (#{@version.number}-zomg)", @version.to_title
+    end
+
+    should "give content address, platform and Ruby ABI for #to_title" do
+      rubygem = create(:rubygem, name: "nokogiri")
+      version = build(
+        :version,
+        rubygem: rubygem,
+        number: "1.18.9",
+        platform: "arm64-darwin-25",
+        gem_platform: "arm64-darwin-25",
+        required_ruby_version: "~> 3.4.0",
+        ruby_abi: "3.4",
+        sha256: Digest::SHA2.base64digest("content addressable gem")
+      )
+      expected_content_address = version.sha256_hex.first(Version::DEFAULT_CONTENT_ADDRESS_LENGTH).to_s
+
+      assert_equal "nokogiri (1.18.9-#{expected_content_address}, Platform: arm64-darwin-25, Ruby ABI 3.4)", version.to_title
     end
 
     should "have description for info" do


### PR DESCRIPTION
### Changes:

- Adds a feature flag `CONTENT_ADDRESSABLE_GEM_PUSHES`.
- Adds a `content_addressable?` predicate on Version.
- Updates the push flow (and `Version` callback) to only set `ruby_abi` if the user has the feature flag enabled..
- Normalizes skinny gem pushes by setting the required RubyGems version floor server-side.
- Updates the push success message for skinny gems to include the platform and Ruby ABI.
- Surfaces the Ruby ABI on the gem page:

<img width="450" height="130" alt="image" src="https://github.com/user-attachments/assets/baf78946-0f09-4550-aca7-de92079ea561" />
<img width="278" height="134" alt="image" src="https://github.com/user-attachments/assets/f0c98d21-6070-4e16-b239-a2d460429d26" />

### Testing:
Tests added to cover the skinny gem push gate, push flow short-circuiting, metadata normalization and version callback logic. Also tested the order of operations for the normalization so that we have a regression guard in place, as if this method is moved we risk overwriting the new `required_rubygems_version` from an incorrect or null value in the gemspec later in the flow.  

To tophat:

1. Enable the feature flag for your user.
2. Push a test skinny gem to your rubygems.org localhost and confirm it succeeds.
3. Confirm the pushed version has:

```
version.required_rubygems_version
  # => ">= 4.1.0.dev"
```

4. Disable the feature flag and confirm pushing a skinny gem is rejected.
5. Set up a version with a Ruby ABI in your local DB and confirm that this is visible in the browser view.

Note - I've tophatted the above successfully and can confirm it's looking good! 