### PR TITLE
[Content Addressable] Part 5: Add Ruby ABI and content address to compact Index data

### DIFF
--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -50,17 +50,17 @@ class GemInfo
     checksum_column = config[:checksum_column]
     yanked_checksum_column = config[:yanked_checksum_column]
 
-    query = ["(SELECT r.name, v.created_at as date, v.#{checksum_column} as info_checksum, v.number, v.platform
+    query = ["(SELECT r.name, v.created_at as date, v.#{checksum_column} as info_checksum, v.number, v.platform, v.ruby_abi, v.full_name
               FROM rubygems AS r, versions AS v
               WHERE v.rubygem_id = r.id AND
                     v.created_at > ?)
               UNION
-              (SELECT r.name, v.yanked_at as date, v.#{yanked_checksum_column} as info_checksum, '-'||v.number, v.platform
+              (SELECT r.name, v.yanked_at as date, v.#{yanked_checksum_column} as info_checksum, '-'||v.number, v.platform, v.ruby_abi, v.full_name
               FROM rubygems AS r, versions AS v
               WHERE v.rubygem_id = r.id AND
                     v.indexed is false AND
                     v.yanked_at > ?)
-              ORDER BY date, number, platform, name", date, date]
+              ORDER BY date, number, platform, ruby_abi, full_name, name", date, date]
 
     map_gem_versions(execute_raw_sql(query).map { |v| [v["name"], [v]] })
   end
@@ -72,11 +72,11 @@ class GemInfo
 
     query = ["SELECT r.name, v.indexed, COALESCE(v.yanked_at, v.created_at) as stamp,
                      v.sha256, COALESCE(v.#{yanked_checksum_column}, v.#{checksum_column}) as info_checksum,
-                     v.number, v.platform
+                     v.number, v.platform, v.ruby_abi, v.full_name
               FROM rubygems AS r, versions AS v
               WHERE v.rubygem_id = r.id AND
                     (v.created_at <= ? OR v.yanked_at <= ?)
-              ORDER BY r.name, stamp, v.number, v.platform", updated_at, updated_at]
+              ORDER BY r.name, stamp, v.number, v.platform, v.ruby_abi, v.full_name", updated_at, updated_at]
 
     versions_by_gem = execute_raw_sql(query).group_by { |v| v["name"] }
     versions_by_gem.each_value do |versions|
@@ -95,13 +95,27 @@ class GemInfo
     ActiveRecord::Base.connection.execute(sanitized_sql)
   end
 
+  def self.content_address_for(ruby_abi, full_name)
+    return if ruby_abi.blank?
+    return if full_name.blank?
+
+    content_address = full_name.split("-")&.last
+    return unless content_address.match?(/\A[0-9a-f]{#{Version::DEFAULT_CONTENT_ADDRESS_LENGTH},64}\z/o)
+
+    content_address
+  end
+
   def self.map_gem_versions(versions_by_gem)
     versions_by_gem.map do |gem_name, versions|
       compact_index_versions = versions.map do |version|
-        CompactIndex::GemVersion.new(version["number"],
-          version["platform"],
-          version["sha256"],
-          version["info_checksum"])
+        CompactIndex::GemVersion.new(
+          number: version["number"],
+          platform: version["platform"],
+          checksum: version["sha256"],
+          info_checksum: version["info_checksum"],
+          ruby_abi: version["ruby_abi"],
+          content_address: content_address_for(version["ruby_abi"], version["full_name"])
+        )
       end
       CompactIndex::Gem.new(gem_name, compact_index_versions)
     end
@@ -111,9 +125,9 @@ class GemInfo
 
   private
 
-  DEPENDENCY_NAMES_INDEX = 8
+  DEPENDENCY_NAMES_INDEX = 10
 
-  DEPENDENCY_REQUIREMENTS_INDEX = 7
+  DEPENDENCY_REQUIREMENTS_INDEX = 9
 
   # Marshal.load of pre-deploy cache entries fails when GemVersion grows a Struct field.
   def read_cache(cache_key)
@@ -134,11 +148,21 @@ class GemInfo
         end
       end
 
-      number, platform, checksum, info_checksum, ruby_version, rubygems_version, created_at, = row
+      number, platform, checksum, info_checksum, ruby_version, rubygems_version, created_at, ruby_abi, full_name, = row
       version_class = VERSIONS.dig(version, :klass)
       checksum = Version._sha256_hex(checksum)
       created_at = created_at&.utc&.iso8601
-      args = { number:, platform:, checksum:, info_checksum:, dependencies:, ruby_version:, rubygems_version:, created_at: }
+      content_address = self.class.content_address_for(ruby_abi, full_name)
+      args = { number:,
+              platform:,
+              checksum:,
+              info_checksum:,
+              dependencies:,
+              ruby_version:,
+              rubygems_version:,
+              created_at:,
+              ruby_abi:,
+              content_address: }
       args = args.slice(*version_class.members)
       version_class.new(**args)
     end
@@ -153,7 +177,7 @@ class GemInfo
     checksum_column = VERSIONS.fetch(version).fetch(:checksum_column)
     group_by_columns = [
       "number", "platform", "sha256", checksum_column,
-      "required_ruby_version", "required_rubygems_version", "versions.created_at"
+      "required_ruby_version", "required_rubygems_version", "versions.created_at", "ruby_abi", "full_name"
     ]
 
     dep_req_agg = "string_agg(dependencies.requirements, '@' ORDER BY rubygems_dependencies.name, dependencies.id)"

--- a/lib/compact_index/gem_version.rb
+++ b/lib/compact_index/gem_version.rb
@@ -2,7 +2,9 @@
 
 module CompactIndex
   module GemVersionMethods
-    def number_and_platform
+    def version_token
+      return "#{number}-#{content_address}" if ruby_abi.present? && content_address.present?
+
       if platform.nil? || platform == "ruby"
         number
       else
@@ -14,16 +16,18 @@ module CompactIndex
       number_comp = number <=> other.number
 
       if number_comp.zero?
-        [number, platform].compact <=> [other.number, other.platform].compact
+        [platform, ruby_abi, content_address].compact <=>
+          [other.platform, other.ruby_abi, other.content_address].compact
       else
         number_comp
       end
     end
 
     def to_line
-      line = "#{number_and_platform} #{deps_line}|checksum:#{checksum}"
+      line = "#{version_token} #{deps_line}|checksum:#{checksum}"
       line << ",ruby:#{ruby_version_line}" if ruby_version && ruby_version != ">= 0"
       line << ",rubygems:#{rubygems_version_line}" if rubygems_version && rubygems_version != ">= 0"
+      line << ",platform:= #{platform}" if ruby_abi.present? && content_address.present?
       line
     end
 
@@ -52,14 +56,15 @@ module CompactIndex
     end
   end
 
+  # TODO: Remove GemVersion as this was missed in the first V1 cleanup
   GemVersion = Struct.new(:number, :platform, :checksum, :info_checksum,
-                          :dependencies, :ruby_version, :rubygems_version) do
+                          :dependencies, :ruby_version, :rubygems_version, :ruby_abi, :content_address) do
     include GemVersionMethods
   end
 
   GemVersionV2 = Struct.new(:number, :platform, :checksum, :info_checksum,
                             :dependencies, :ruby_version, :rubygems_version,
-                            :created_at) do
+                            :created_at, :ruby_abi, :content_address) do
     include GemVersionMethods
 
     def to_line

--- a/lib/compact_index/versions_file.rb
+++ b/lib/compact_index/versions_file.rb
@@ -37,7 +37,7 @@ module CompactIndex
 
     def gem_lines(gems)
       gems.reduce(+"") do |lines, gem|
-        version_numbers = gem.versions.map(&:number_and_platform).join(",")
+        version_numbers = gem.versions.map(&:version_token).join(",")
         lines << gem.name <<
           " " << version_numbers <<
           " #{gem.versions.last.info_checksum}\n"

--- a/test/helpers/compact_index_helpers.rb
+++ b/test/helpers/compact_index_helpers.rb
@@ -11,10 +11,12 @@ module CompactIndexHelpers
       args.fetch(:info_checksum, "info+#{name}+#{number}"),
       args[:dependencies],
       args[:ruby_version],
-      args[:rubygems_version]
+      args[:rubygems_version],
+      args[:ruby_abi],
+      args[:content_address]
     ]
     if version == 2
-      CompactIndex::GemVersionV2.new(*common, args[:created_at])
+      CompactIndex::GemVersionV2.new(*common[0...7], args[:created_at], *common[7..])
     else
       CompactIndex::GemVersion.new(*common)
     end

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -93,6 +93,28 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
   end
 
+  test "/versions includes content-addressable versions for gems which support single Ruby ABI" do
+    rubygem = create(:rubygem, name: "v2rubyabi")
+    version = create(
+      :version,
+      rubygem:,
+      number: "2.9.0",
+      platform: "x86_64-linux-musl",
+      gem_platform: "x86_64-linux-musl",
+      required_ruby_version: "~> 3.2.0",
+      required_rubygems_version: ">= 4.1.0.dev",
+      sha256: Digest::SHA2.base64digest("v2rubyabi-2.9.0-x86_64-linux-musl"),
+      created_at: Time.utc(2026, 5, 1, 12, 0, 0)
+    )
+
+    content_address = version.full_name.split("-").last
+
+    get versions_path
+
+    assert_response :success
+    assert_includes @response.body, "v2rubyabi 2.9.0-#{content_address} #{current_checksum(version)}"
+  end
+
   test "/versions partial response" do
     get versions_path
     full_response_body = @response.body
@@ -173,6 +195,70 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
     assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
     assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
     assert_equal "#{current_info_prefix}/* gem/v2gem #{current_info_prefix}/v2gem", @response.headers["Surrogate-Key"]
+  end
+
+  test "/info serves correct format for gem which supports single Ruby ABI" do
+    rubygem = create(:rubygem, name: "v2rubyabi")
+    version = create(
+      :version,
+      rubygem:,
+      number: "2.9.0",
+      platform: "x86_64-linux-musl",
+      gem_platform: "x86_64-linux-musl",
+      required_ruby_version: "~> 3.2.0",
+      required_rubygems_version: ">= 4.1.0.dev",
+      sha256: Digest::SHA2.base64digest("v2rubyabi-2.9.0-x86_64-linux-musl"),
+      created_at: Time.utc(2026, 5, 1, 12, 0, 0)
+    )
+
+    content_address = version.full_name.split("-").last
+
+    expected = <<~VERSIONS_FILE
+      ---
+      2.9.0-#{content_address} |checksum:#{Version._sha256_hex(version.sha256)},ruby:~> 3.2.0,rubygems:>= 4.1.0.dev,platform:= x86_64-linux-musl,created_at:#{version.created_at.utc.iso8601}
+    VERSIONS_FILE
+
+    expected_digest = digest(expected)
+
+    get info_path(gem_name: "v2rubyabi")
+
+    assert_response :success
+    assert_equal expected, @response.body
+    assert_equal etag(expected), @response.headers["ETag"]
+    assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
+    assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
+    assert_equal "#{current_info_prefix}/* gem/v2rubyabi #{current_info_prefix}/v2rubyabi", @response.headers["Surrogate-Key"]
+  end
+
+  test "/info serves correct format for gem which supports multiple Ruby ABIs" do
+    rubygem = create(:rubygem, name: "v2multiabi")
+    version = create(
+      :version,
+      rubygem:,
+      number: "2.9.0",
+      platform: "x86_64-linux-musl",
+      gem_platform: "x86_64-linux-musl",
+      required_ruby_version: ">= 3.2.0",
+      required_rubygems_version: ">= 4.1.0.dev",
+      sha256: Digest::SHA2.base64digest("v2multiabi-2.9.0-x86_64-linux-musl"),
+      created_at: Time.utc(2026, 5, 1, 12, 0, 0)
+    )
+
+    expected = <<~VERSIONS_FILE
+      ---
+      2.9.0-x86_64-linux-musl |checksum:#{Version._sha256_hex(version.sha256)},ruby:>= 3.2.0,rubygems:>= 4.1.0.dev,created_at:#{version.created_at.utc.iso8601}
+    VERSIONS_FILE
+
+    expected_digest = digest(expected)
+
+    get info_path(gem_name: "v2multiabi")
+
+    assert_response :success
+    assert_equal expected, @response.body
+    assert_equal etag(expected), @response.headers["ETag"]
+    assert_equal "sha-256=#{expected_digest}", @response.headers["Digest"]
+    assert_equal "sha-256=:#{expected_digest}:", @response.headers["Repr-Digest"]
+    assert_equal "#{current_info_prefix}/* gem/v2multiabi #{current_info_prefix}/v2multiabi", @response.headers["Surrogate-Key"]
   end
 
   test "/info partial response" do

--- a/test/lib/compact_index/gem_version_test.rb
+++ b/test/lib/compact_index/gem_version_test.rb
@@ -29,9 +29,45 @@ class CompactIndex::GemVersionTest < ActiveSupport::TestCase
 
       assert_equal 0, v1 <=> v2
     end
+
+    should "sort by Ruby ABI and content address when numbers and platforms are equal" do
+      v1 = build_version(
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        ruby_abi: "3.2",
+        content_address: "ef716ba7"
+      )
+      v2 = build_version(
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        ruby_abi: "3.3",
+        content_address: "ab123456"
+      )
+
+      assert_equal(-1, v1 <=> v2)
+      assert_equal 1, v2 <=> v1
+    end
   end
 
   context "#to_line" do
+    should "use content address and platform metadata for Ruby ABI versions" do
+      version = build_version(
+        version: 2,
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        checksum: "ef716ba7abcdef",
+        ruby_version: "~> 3.2.0",
+        rubygems_version: ">= 4.1.0.dev",
+        ruby_abi: "3.2",
+        content_address: "ef716ba7"
+      )
+
+      assert_equal(
+        "2.9.0-ef716ba7 |checksum:ef716ba7abcdef,ruby:~> 3.2.0,rubygems:>= 4.1.0.dev,platform:= x86_64-linux-musl",
+        version.to_line
+      )
+    end
+
     should "not include created_at for v1" do
       v = build_version(number: "1.0")
 

--- a/test/lib/compact_index/versions_file_test.rb
+++ b/test/lib/compact_index/versions_file_test.rb
@@ -119,6 +119,21 @@ class CompactIndex::VersionsFileTest < ActiveSupport::TestCase
   end
 
   context "#contents" do
+    should "use content address for Ruby ABI version tokens" do
+      versions = [
+        build_version(
+          name: "test",
+          number: "2.9.0",
+          platform: "x86_64-linux-musl",
+          ruby_abi: "3.2",
+          content_address: "ef716ba7"
+        )
+      ]
+      gems = [CompactIndex::Gem.new("test", versions)]
+
+      assert_includes @versions_file.contents(gems), "test 2.9.0-ef716ba7 info+test+2.9.0"
+    end
+
     should "raise when there are unknown options" do
       assert_raises(ArgumentError) { @versions_file.contents(nil, foo: :bar) }
     end

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -34,6 +34,48 @@ class GemInfoTest < ActiveSupport::TestCase
       @expected_info_checksum = Digest::MD5.hexdigest(CompactIndex.info(@expected_info))
     end
 
+    should "include Ruby ABI and content address in info version targeting a single Ruby ABI" do
+      rubygem = create(:rubygem, name: "single-abi-info")
+      version = create(
+        :version,
+        rubygem: rubygem,
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        gem_platform: "x86_64-linux-musl",
+        required_ruby_version: "~> 3.2.0",
+        sha256: Digest::SHA2.base64digest("single-abi-2.9.0-x86_64-linux-musl"),
+        info_checksum_v2: "single-abi-info-checksum"
+      )
+
+      info = GemInfo.new("single-abi-info").compact_index_info
+      compact_index_version = info.first
+
+      assert_equal "3.2", compact_index_version.ruby_abi
+      assert_equal version.full_name.split("-").last, compact_index_version.content_address
+    end
+
+    should "return platform identity without Ruby ABI or content address for versions targeting multiple Ruby ABIs" do
+      rubygem = create(:rubygem, name: "multi-abi")
+      create(
+        :version,
+        rubygem: rubygem,
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        gem_platform: "x86_64-linux-musl",
+        required_ruby_version: ">= 3.2.0",
+        sha256: Digest::SHA2.base64digest("multi-abi-2.9.0-x86_64-linux-musl"),
+        info_checksum_v2: "multi-abi-info-checksum"
+      )
+
+      info = GemInfo.new("multi-abi").compact_index_info
+      compact_index_version = info.first
+
+      assert_equal "2.9.0", compact_index_version.number
+      assert_equal "x86_64-linux-musl", compact_index_version.platform
+      assert_nil compact_index_version.ruby_abi
+      assert_nil compact_index_version.content_address
+    end
+
     should "return v2 gem version and dependency with created_at" do
       info = GemInfo.new("example").compact_index_info
 
@@ -110,6 +152,27 @@ class GemInfoTest < ActiveSupport::TestCase
          CompactIndex::Gem.new("foo", [CompactIndex::GemVersion.new("2.0.0", "ruby", nil, "v2qw2dwe")])]
     end
 
+    should "include Ruby ABI and content address for created versions" do
+      rubygem = create(:rubygem, name: "skinny")
+      version = create(
+        :version,
+        rubygem: rubygem,
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        gem_platform: "x86_64-linux-musl",
+        required_ruby_version: "~> 3.2.0",
+        sha256: Digest::SHA2.base64digest("skinny-2.9.0-x86_64-linux-musl"),
+        created_at: 2.days.ago,
+        info_checksum_v2: "skinny-info"
+      )
+
+      versions = GemInfo.compact_index_versions(3.days.ago)
+      gem = versions.find { |compact_index_gem| compact_index_gem.name == "skinny" }
+
+      assert_equal "3.2", gem.versions.first.ruby_abi
+      assert_equal version.full_name.split("-").last, gem.versions.first.content_address
+    end
+
     should "return all versions created after given date using v2 checksum" do
       versions = GemInfo.compact_index_versions(4.days.ago)
 
@@ -145,6 +208,27 @@ class GemInfoTest < ActiveSupport::TestCase
       )]
 
       assert_equal expected_versions, versions
+    end
+
+    should "include Ruby ABI and content address for public versions" do
+      rubygem = create(:rubygem, name: "skinny-public")
+      version = create(
+        :version,
+        rubygem: rubygem,
+        number: "2.9.0",
+        platform: "x86_64-linux-musl",
+        gem_platform: "x86_64-linux-musl",
+        required_ruby_version: "~> 3.2.0",
+        sha256: Digest::SHA2.base64digest("skinny-public-2.9.0-x86_64-linux-musl"),
+        created_at: @ts,
+        info_checksum_v2: "skinny-public-info"
+      )
+
+      versions = GemInfo.compact_index_public_versions(@ts)
+      gem = versions.find { |compact_index_gem| compact_index_gem.name == "skinny-public" }
+
+      assert_equal "3.2", gem.versions.first.ruby_abi
+      assert_equal version.full_name.split("-").last, gem.versions.first.content_address
     end
 
     should "not return yanked versions" do


### PR DESCRIPTION
### Changes
- Include `ruby_abi` and `full_name` in the compact index query data, then maps `full_name` to a `content_address` on compact index version structs.
- Uses content-addressable version tokens for Ruby ABI-specific platform gems, e.g. `2.9.0-2f716ba7`. 
- Add `platform: ....` metadata to Ruby ABI-specific compact index lines. 
- Ensure the new values are considered as tie-brakers in query ordering and custom ordering methods (i.e. `<=>`).

### Tests
- Changes are covered in `compact_index_test`, `gem_version_test`, `version_file_test` and `gem_info_test`. 
- Covers both /info/<gem> and /versions endpoint output.

### Tophat

  Run migrations, then create test versions in `bin/rails console`:

  ```
  content_rubygem = Rubygem.find_or_create_by!(name: "ca-compact-index-tophat") { |gem| gem.indexed =
  true }

  content_version = Version.create!(
    rubygem: content_rubygem,
    number: "2.9.0",
    platform: "x86_64-linux-musl",
    gem_platform: "x86_64-linux-musl",
    required_ruby_version: "~> 3.2.0",
    required_rubygems_version: ">= 4.1.0.dev",
    authors: ["Harriet Oughton"],
    sha256: Digest::SHA2.base64digest("ca-compact-index-tophat-2.9.0-x86_64-linux-musl"),
    info_checksum_v2: "ca-compact-index-tophat-info-checksum",
    indexed: true
  )

  fat_rubygem = Rubygem.find_or_create_by!(name: "ca-compact-index-fat-tophat") { |gem| gem.indexed =
  true }

  fat_version = Version.create!(
    rubygem: fat_rubygem,
    number: "2.9.0",
    platform: "x86_64-linux-musl",
    gem_platform: "x86_64-linux-musl",
    required_ruby_version: ">= 3.2",
    required_rubygems_version: ">= 3.3.22",
    authors: ["Harriet Oughton"],
    sha256: Digest::SHA2.base64digest("ca-compact-index-fat-tophat-2.9.0-x86_64-linux-musl"),
    info_checksum_v2: "ca-compact-index-fat-tophat-info-checksum",
    indexed: true
  )

  ruby_platform_rubygem = Rubygem.find_or_create_by!(name: "ca-compact-index-ruby-platform-tophat")
  { |gem| gem.indexed = true }

  ruby_platform_version = Version.create!(
    rubygem: ruby_platform_rubygem,
    number: "1.0.0",
    platform: "ruby",
    gem_platform: "ruby",
    required_ruby_version: "~> 3.2.0",
    required_rubygems_version: ">= 4.1.0.dev",
    authors: ["Harriet Oughton"],
    sha256: Digest::SHA2.base64digest("ca-compact-index-ruby-platform-tophat-1.0.0"),
    info_checksum_v2: "ca-compact-index-ruby-platform-tophat-info-checksum",
    indexed: true
  )

  {
    content_addressable: content_version.slice(:number, :platform, :ruby_abi, :full_name),
    fat: fat_version.slice(:number, :platform, :ruby_abi, :full_name),
    ruby_platform: ruby_platform_version.slice(:number, :platform, :ruby_abi, :full_name)
  }

  With the Rails server running, check compact index output:

  curl -s http://localhost:3000/info/ca-compact-index-tophat
  curl -s http://localhost:3000/versions | grep ca-compact-index-tophat

  curl -s http://localhost:3000/info/ca-compact-index-fat-tophat
  curl -s http://localhost:3000/versions | grep ca-compact-index-fat-tophat

  curl -s http://localhost:3000/info/ca-compact-index-ruby-platform-tophat
  curl -s http://localhost:3000/versions | grep ca-compact-index-ruby-platform-tophat
```

  Expected:

  - ca-compact-index-tophat uses 2.9.0-<digest> and includes platform:x86_64-linux-musl.
  - ca-compact-index-fat-tophat keeps 2.9.0-x86_64-linux-musl and does not include platform:.
  - ca-compact-index-ruby-platform-tophat keeps 1.0.0 and does not produce 1.0.0- or 1.0.0-1.0.0.