### PR TITLE
Allow yanking a specific Ruby ABI variant

### DIFF
--- a/app/avo/resources/deletion.rb
+++ b/app/avo/resources/deletion.rb
@@ -10,6 +10,7 @@ class Avo::Resources::Deletion < Avo::BaseResource
     field :rubygem, as: :text
     field :number, as: :text
     field :platform, as: :text
+    field :ruby_abi, as: :text, title: "Ruby ABI"
     field :user, as: :belongs_to
     field :version, as: :belongs_to
   end

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -40,9 +40,17 @@ class Api::V1::DeletionsController < Api::BaseController
       begin
         version = params.expect(:version)
         platform = params.permit(:platform).fetch(:platform, nil)
-        @version = @rubygem.find_version!(number: version, platform: platform)
+        ruby_abi = params.permit(:ruby_abi).fetch(:ruby_abi, nil).presence
+
+        if ruby_abi.present? && platform.blank?
+          return render plain: response_with_mfa_warning("The platform param is required when ruby_abi is specified."),
+                        status: :bad_request
+        end
+
+        @version = @rubygem.find_version!(number: version, platform: platform, ruby_abi: ruby_abi)
       rescue ActiveRecord::RecordNotFound
-        render plain: response_with_mfa_warning("The version #{version}#{" (#{platform})" if platform.present?} does not exist."),
+        details = "#{" (#{platform})" if platform.present?}#{" (Ruby ABI #{ruby_abi})" if ruby_abi.present?}"
+        render plain: response_with_mfa_warning("The version #{version}#{details} does not exist."),
                status: :not_found
       end
     end

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -54,6 +54,7 @@ class Deletion < ApplicationRecord
       reason: ineligible_reason,
       number: version.number,
       platform: version.platform,
+      ruby_abi: version.ruby_abi,
       yanked_by: user.display_handle,
       actor_gid: user.to_gid,
       version_gid: version.to_gid
@@ -75,6 +76,7 @@ class Deletion < ApplicationRecord
     errors.add(:rubygem, "does not match version rubygem name") unless rubygem == version.rubygem.name
     errors.add(:number, "does not match version number") unless number == version.number
     errors.add(:platform, "does not match version platform") unless platform == version.platform
+    errors.add(:ruby_abi, "does not match version Ruby ABI") unless ruby_abi == version.ruby_abi
   end
 
   def rubygem_name
@@ -85,6 +87,7 @@ class Deletion < ApplicationRecord
     self.rubygem = rubygem_name
     self.number = version.number
     self.platform = version.platform
+    self.ruby_abi = version.ruby_abi
   end
 
   def expire_cache
@@ -155,11 +158,11 @@ class Deletion < ApplicationRecord
 
   def record_yank_event
     version.rubygem.record_event!(Events::RubygemEvent::VERSION_YANKED, number: version.number, platform: version.platform,
-yanked_by: user&.display_handle, actor_gid: user&.to_gid, version_gid: version.to_gid, force:)
+ruby_abi: version.ruby_abi, yanked_by: user&.display_handle, actor_gid: user&.to_gid, version_gid: version.to_gid, force:)
   end
 
   def record_unyank_event
     version.rubygem.record_event!(Events::RubygemEvent::VERSION_UNYANKED, number: version.number, platform: version.platform,
-version_gid: version.to_gid)
+ruby_abi: version.ruby_abi, version_gid: version.to_gid)
   end
 end

--- a/app/models/events/rubygem_event.rb
+++ b/app/models/events/rubygem_event.rb
@@ -19,6 +19,7 @@ class Events::RubygemEvent < ApplicationRecord
   VERSION_YANKED = define_event "rubygem:version:yanked" do
     attribute :number, :string
     attribute :platform, :string
+    attribute :ruby_abi, :string
 
     attribute :yanked_by, :string
 
@@ -30,6 +31,7 @@ class Events::RubygemEvent < ApplicationRecord
   VERSION_YANK_FORBIDDEN = define_event "rubygem:version:yank_forbidden" do
     attribute :number, :string
     attribute :platform, :string
+    attribute :ruby_abi, :string
 
     attribute :yanked_by, :string
 
@@ -41,6 +43,7 @@ class Events::RubygemEvent < ApplicationRecord
   VERSION_UNYANKED = define_event "rubygem:version:unyanked" do
     attribute :number, :string
     attribute :platform, :string
+    attribute :ruby_abi, :string
 
     attribute :version_gid, :global_id
   end

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -199,9 +199,9 @@ class Rubygem < ApplicationRecord
     payload(version).merge!(version.as_json) if version
   end
 
-  def find_version!(number:, platform:)
+  def find_version!(number:, platform:, ruby_abi: nil)
     platform = platform.presence || "ruby"
-    versions.find_by!(number: number, platform: platform)
+    versions.find_by!(number: number, platform: platform, ruby_abi: ruby_abi)
   end
 
   def find_version_by_slug!(slug)

--- a/db/migrate/20260811160835_add_ruby_abi_to_deletions.rb
+++ b/db/migrate/20260811160835_add_ruby_abi_to_deletions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRubyAbiToDeletions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :deletions, :ruby_abi, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_23_061553) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_160835) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -148,6 +148,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_061553) do
     t.datetime "created_at", precision: nil, null: false
     t.string "number"
     t.string "platform"
+    t.string "ruby_abi"
     t.string "rubygem"
     t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id"

--- a/script/restore_version
+++ b/script/restore_version
@@ -1,20 +1,24 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-gem_name, version_number, platform = *ARGV
+gem_name, version_number, platform, ruby_abi = *ARGV
 
-abort "Usage: script/restore_version GEM_NAME VESRION_NUMBER [PLATFORM]" if gem_name.nil? || version_number.nil?
+abort "Usage: script/restore_version GEM_NAME VERSION_NUMBER [PLATFORM] [RUBY_ABI]" if gem_name.nil? || version_number.nil?
 
 ENV["RAILS_ENV"] ||= "production"
 require_relative "../config/environment"
 
 rubygem = Rubygem.find_by_name!(gem_name)
-slug = version_number
+slug = version_number.dup
 slug << "-#{platform}" if platform.present?
-version = rubygem.find_version!(number: version_number, platform: platform)
-raise "Version #{slug} for #{gem_name} was not found" unless version
+slug << " (Ruby ABI #{ruby_abi})" if ruby_abi.present?
+begin
+  version = rubygem.find_version!(number: version_number, platform: platform, ruby_abi: ruby_abi.presence)
+rescue ActiveRecord::RecordNotFound
+  abort "Version #{slug} for #{gem_name} was not found"
+end
 
-deletion = Deletion.find_by(rubygem: gem_name, number: version_number, platform: version.platform)
+deletion = Deletion.find_by(rubygem: gem_name, number: version_number, platform: version.platform, ruby_abi: version.ruby_abi)
 raise "Deletion record for version: #{version.full_name} was not found" unless deletion
 
 deletion.version = version

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -32,6 +32,131 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
       end
     end
 
+    context "for a gem with content-addressable versions across Ruby ABIs" do
+      setup do
+        @rubygem = create(:rubygem, name: "sandworm")
+        @abi32 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.2"))
+        @abi34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.4"))
+        create(:ownership, user: @user, rubygem: @rubygem)
+        RubygemFs.instance.store("gems/#{@abi32.full_name}.gem", "")
+        RubygemFs.instance.store("gems/#{@abi34.full_name}.gem", "")
+      end
+
+      context "ON DELETE with a ruby_abi param" do
+        setup do
+          delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.2" }
+        end
+
+        should respond_with :success
+
+        should "yank only the targeted Ruby ABI variant" do
+          refute_predicate @abi32.reload, :indexed?
+          assert_predicate @abi34.reload, :indexed?
+        end
+
+        should "respond with the deleted variant including its content address and Ruby ABI" do
+          assert_includes @response.body, "Successfully deleted gem: sandworm (1.0.0-724c5206, Platform: x86_64-linux-musl, Ruby ABI 3.2)"
+        end
+      end
+
+      context "ON DELETE without a ruby_abi param" do
+        setup do
+          delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl" }
+        end
+
+        should respond_with :not_found
+
+        should "not yank either Ruby ABI variant" do
+          assert_predicate @abi32.reload, :indexed?
+          assert_predicate @abi34.reload, :indexed?
+        end
+
+        should "respond that the version does not exist" do
+          assert_includes @response.body, "The version 1.0.0 (x86_64-linux-musl) does not exist."
+        end
+      end
+
+      context "ON DELETE with a ruby_abi param that does not match any variant" do
+        setup do
+          delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.3" }
+        end
+
+        should respond_with :not_found
+
+        should "not yank either Ruby ABI variant" do
+          assert_predicate @abi32.reload, :indexed?
+          assert_predicate @abi34.reload, :indexed?
+        end
+
+        should "respond that the version does not exist" do
+          assert_includes @response.body, "The version 1.0.0 (x86_64-linux-musl) (Ruby ABI 3.3) does not exist."
+        end
+      end
+
+      context "ON DELETE with a ruby_abi param but no platform" do
+        setup do
+          delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", ruby_abi: "3.2" }
+        end
+
+        should respond_with :bad_request
+
+        should "not yank either Ruby ABI variant" do
+          assert_predicate @abi32.reload, :indexed?
+          assert_predicate @abi34.reload, :indexed?
+        end
+
+        should "respond that the platform param is required" do
+          assert_includes @response.body, "The platform param is required when ruby_abi is specified."
+        end
+      end
+
+      context "when a version supporting multiple Ruby ABIs coexists" do
+        setup do
+          @multi_abi = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                              required_ruby_version: ">= 3.2")
+          RubygemFs.instance.store("gems/#{@multi_abi.full_name}.gem", "")
+        end
+
+        context "ON DELETE with only a platform param" do
+          setup do
+            delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl" }
+          end
+
+          should respond_with :success
+
+          should "yank only the version supporting multiple Ruby ABIs and keep the single ABI variants" do
+            refute_predicate @multi_abi.reload, :indexed?
+            assert_predicate @abi32.reload, :indexed?
+            assert_predicate @abi34.reload, :indexed?
+          end
+
+          should "respond with the deleted platform version" do
+            assert_includes @response.body, "Successfully deleted gem: sandworm (1.0.0-x86_64-linux-musl)"
+          end
+        end
+
+        context "ON DELETE with an empty ruby_abi param" do
+          setup do
+            delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "" }
+          end
+
+          should respond_with :success
+
+          should "treat the empty ruby_abi as absent and yank the version supporting multiple Ruby ABIs" do
+            refute_predicate @multi_abi.reload, :indexed?
+            assert_predicate @abi32.reload, :indexed?
+            assert_predicate @abi34.reload, :indexed?
+          end
+
+          should "respond with the deleted platform version" do
+            assert_includes @response.body, "Successfully deleted gem: sandworm (1.0.0-x86_64-linux-musl)"
+          end
+        end
+      end
+    end
+
     context "for a gem SomeGem with a version 0.1.0" do
       setup do
         @rubygem   = create(:rubygem, name: "SomeGem")

--- a/test/models/deletion_test.rb
+++ b/test/models/deletion_test.rb
@@ -185,6 +185,16 @@ class DeletionTest < ActiveSupport::TestCase
 
     assert_equal deletion.rubygem, @version.rubygem.name
     assert_equal @version.id, deletion.version_id
+    assert_nil deletion.ruby_abi
+  end
+
+  should "record the Ruby ABI for versions targeting a single Ruby ABI" do
+    version = create(:version, rubygem: @version.rubygem, number: "2.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                     required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("test-2.0.0-3.4"))
+    deletion = Deletion.new(version: version, user: @user)
+    deletion.valid?
+
+    assert_equal "3.4", deletion.ruby_abi
   end
 
   context "with restored gem" do

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -80,6 +80,19 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal version3_ruby, @rubygem.most_recent_version
     end
 
+    should "find versions by number, platform and Ruby ABI" do
+      plain = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                     required_ruby_version: ">= 3.2")
+      abi34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                     required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("abi34-1.0.0"))
+
+      assert_equal plain, @rubygem.find_version!(number: "1.0.0", platform: "x86_64-linux-musl")
+      assert_equal abi34, @rubygem.find_version!(number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.4")
+      assert_raises(ActiveRecord::RecordNotFound) do
+        @rubygem.find_version!(number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.2")
+      end
+    end
+
     should "mark the latest version for each Ruby ABI per platform" do
       abi32_old = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
                          required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("abi32-1.0.0"))

--- a/test/system/avo/versions_test.rb
+++ b/test/system/avo/versions_test.rb
@@ -101,7 +101,7 @@ class Avo::VersionsSystemTest < ApplicationSystemTestCase
               "updated_at" => [deletion.updated_at.as_json, nil],
               "version_id" => [version.id, nil]
             },
-            "unchanged" => {}
+            "unchanged" => { "ruby_abi" => nil }
           },
           version_unyank_event.to_gid.to_s => {
             "changes" => version_unyank_event.attributes.transform_values { [nil, it] }.as_json,


### PR DESCRIPTION
https://github.com/rubygems/rubygems.org/pull/6674

### Problem

Content-addressable gems mean multiple versions can now share the same `number` and `platform` — one per Ruby ABI:

```
sandworm 1.0.0 x86_64-linux-musl  ruby_abi=3.2  → sandworm-1.0.0-724c5206
sandworm 1.0.0 x86_64-linux-musl  ruby_abi=3.4  → sandworm-1.0.0-9f8e7d6c
```

The deletions API resolves the version to yank via `Rubygem#find_version!(number:, platform:)`, which uses `find_by!` — so `gem yank sandworm -v 1.0.0 --platform x86_64-linux-musl` would match **both** rows and delete whichever the database returned first. A destructive operation should never pick its target arbitrarily.

### Solution

`find_version!` now scopes on `ruby_abi`, defaulting to `nil`, and the deletions API accepts an optional `ruby_abi` param:

| Request | Result |
|---|---|
| `platform` + matching `ruby_abi` | ✅ yanks exactly that variant |
| `platform` + `ruby_abi` matching no variant | 404 |
| `platform` only, when only ABI variants exist | 404 — nothing is deleted arbitrarily |
| `platform` only, when a version supporting multiple Ruby ABIs coexists | ✅ yanks only that version; ABI variants untouched |
| `ruby_abi` without `platform` | 400 — a platform is required (ABI gems are always platformed) |
| empty `ruby_abi` param | treated as absent (normalized with `.presence`, matching `platform`'s existing handling) |

### Testing

Push three real `.gem` files (ABI 3.2 + 3.4 variants and a version supporting multiple Ruby ABIs, all sharing number + platform) through the full push pipeline with the feature flag enabled, then exercises every yank resolution path, asserting HTTP status, response body, and the indexed state of all three versions after each step.

Run from the repo root with the server on `:3000` — paste the whole block into your console:

<details>
<summary>Tophat script (single paste)</summary>

```bash
bash <<'TOPHAT'
set -uo pipefail

BASE_URL="${BASE_URL:-http://localhost:3000}"
GEM="yanktophat$(date +%s)"
PLATFORM="x86_64-linux-musl"
BUILD_DIR=$(mktemp -d)
PASS=0 FAIL=0

step()  { printf '\n\033[1m== %s\033[0m\n' "$*"; }
ok()    { PASS=$((PASS+1)); printf '  \033[32mPASS\033[0m %s\n' "$*"; }
bad()   { FAIL=$((FAIL+1)); printf '  \033[31mFAIL\033[0m %s\n' "$*"; }

yank() { # yank <desc> <expected_code> <body_substring> -- form args...
  local desc="$1" want_code="$2" want_body="$3"; shift 3; shift # drop --
  local args=() a
  for a in "$@"; do args+=(--data-urlencode "$a"); done
  local resp code body
  resp=$(curl -s -w $'\n%{http_code}' -X DELETE "$BASE_URL/api/v1/gems/yank" \
              -H "Authorization: $KEY" "${args[@]}")
  code=${resp##*$'\n'}
  body=${resp%$'\n'*}
  if [[ "$code" == "$want_code" && "$body" == *"$want_body"* ]]; then
    ok "$desc → $code, body matched"
  else
    bad "$desc → got $code (want $want_code); body: ${body:0:150}"
  fi
}

push() { # push <file> <expected_body_substring>
  local file="$1" want_body="$2" resp code body
  resp=$(curl -s -w $'\n%{http_code}' -X POST "$BASE_URL/api/v1/gems" \
              -H "Authorization: $KEY" -H "Content-Type: application/octet-stream" \
              --data-binary "@$file")
  code=${resp##*$'\n'}
  body=${resp%$'\n'*}
  if [[ "$code" == "200" && "$body" == *"$want_body"* ]]; then
    ok "pushed $(basename "$file") → $code: ${body:0:110}"
  else
    bad "push $(basename "$file") → got $code; body: ${body:0:150}"
  fi
}

state() { # state <desc> <expected "t t t" for abi32 abi34 multi; ? = row absent>
  local desc="$1" want="$2" got
  got=$(bin/rails runner "
    r = Rubygem.find_by!(name: \"$GEM\")
    line = [r.versions.find_by(ruby_abi: \"3.2\"), r.versions.find_by(ruby_abi: \"3.4\"),
            r.versions.find_by(ruby_abi: nil, platform: \"$PLATFORM\")]
             .map { |v| v.nil? ? '?' : (v.indexed ? 't' : 'f') }.join(' ')
    puts \"STATE=#{line}\"" 2>/dev/null | grep "^STATE=" | cut -d= -f2)
  if [[ "$got" == "$want" ]]; then
    ok "$desc (abi32 abi34 multi = $got)"
  else
    bad "$desc — indexed state abi32 abi34 multi = '$got', want '$want'"
  fi
}

step "Preflight: server on :3000"
curl -sf "$BASE_URL/" > /dev/null || { echo "Server not running — start it with ./.agents/skills/run-rubygems-org/smoke.sh"; exit 1; }
ok "server is up"

step "Setup: user + push/yank API key + feature flag"
RUNNER_LOG=$(mktemp)
KEY=$(bin/rails runner "
  user = User.find_or_create_by!(handle: \"yanktophat\") do |u|
    u.email = \"yanktophat@rubygems-test.org\"
    u.password = SecureRandom.hex(16)
    u.email_confirmed = true
  end
  FeatureFlag.enable_for_actor(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, user)
  raw = SecureRandom.hex(24)
  user.api_keys.create!(name: \"tophat-#{SecureRandom.hex(4)}\",
                        hashed_key: Digest::SHA256.hexdigest(raw),
                        scopes: %w[push_rubygem yank_rubygem])
  puts \"KEY=#{raw}\"
" 2>"$RUNNER_LOG" | grep "^KEY=" | cut -d= -f2)
if [[ -n "$KEY" ]]; then
  ok "user + key ready, CONTENT_ADDRESSABLE_GEM_PUSHES enabled"
else
  bad "setup failed — bin/rails runner output:"
  tail -15 "$RUNNER_LOG" | sed 's/^/    /'
  echo "    (common causes: wrong ruby active — .ruby-version wants $(cat .ruby-version), you have $(ruby -v 2>/dev/null | cut -d' ' -f2); or pending migrations: bin/rails db:migrate)"
  exit 1
fi

step "Build: three real .gem files (same number + platform)"
ruby -rrubygems/package -e '
  gem_name, platform, build_dir = ARGV
  [["skinny32", "~> 3.2.0"], ["skinny34", "~> 3.4.0"], ["multi", ">= 3.2"]].each do |label, req|
    dir = File.join(build_dir, label)
    Dir.mkdir(dir)
    spec = Gem::Specification.new do |s|
      s.name        = gem_name
      s.version     = "1.0.0"
      s.platform    = platform
      s.summary     = "yank tophat (#{label})"
      s.authors     = ["tophat"]
      s.files       = []
      s.required_ruby_version = req
    end
    Dir.chdir(dir) { Gem::Package.build(spec) }
  end
' "$GEM" "$PLATFORM" "$BUILD_DIR" > /dev/null 2>&1 \
  && ok "built skinny 3.2 / skinny 3.4 / multi-ABI in $BUILD_DIR" \
  || { bad "gem build failed"; exit 1; }

step "Push: skinny variants through the real pipeline"
push "$BUILD_DIR/skinny32/$GEM-1.0.0-$PLATFORM.gem" "Ruby ABI 3.2"
push "$BUILD_DIR/skinny34/$GEM-1.0.0-$PLATFORM.gem" "Ruby ABI 3.4"

ADDRS=$(bin/rails runner "
  r = Rubygem.find_by!(name: \"$GEM\")
  puts \"ADDR32=#{r.versions.find_by!(ruby_abi: \"3.2\").full_name.split(\"-\").last}\"
  puts \"ADDR34=#{r.versions.find_by!(ruby_abi: \"3.4\").full_name.split(\"-\").last}\"
" 2>/dev/null | grep -E "^ADDR3[24]=")
eval "$ADDRS"
[[ -n "${ADDR32:-}" && -n "${ADDR34:-}" ]] && ok "content addresses: $ADDR32 / $ADDR34" || { bad "could not read content addresses"; exit 1; }
state "both variants indexed after push" "t t ?"

step "Sanity: /info shows content-addressed lines with normalized rubygems floor"
INFO=$(curl -s "$BASE_URL/info/$GEM")
[[ "$INFO" == *"1.0.0-$ADDR32 "* && "$INFO" == *"platform:= $PLATFORM"* && "$INFO" == *"rubygems:>= 4.1.0.beta1"* ]] \
  && ok "/info has 1.0.0-$ADDR32, platform:= metadata and rubygems:>= 4.1.0.beta1" \
  || bad "/info unexpected: ${INFO:0:250}"

step "1. ruby_abi matching no variant -> 404, nothing yanked"
yank "yank ruby_abi=3.3" 404 "The version 1.0.0 ($PLATFORM) (Ruby ABI 3.3) does not exist." -- \
  "gem_name=$GEM" "version=1.0.0" "platform=$PLATFORM" "ruby_abi=3.3"
state "both variants still indexed" "t t ?"

step "2. ruby_abi without platform -> 400"
yank "yank ruby_abi=3.2, no platform" 400 "The platform param is required when ruby_abi is specified." -- \
  "gem_name=$GEM" "version=1.0.0" "ruby_abi=3.2"
state "both variants still indexed" "t t ?"

step "3. platform only, when only ABI variants exist -> 404, nothing yanked"
yank "yank platform only" 404 "The version 1.0.0 ($PLATFORM) does not exist." -- \
  "gem_name=$GEM" "version=1.0.0" "platform=$PLATFORM"
state "both variants still indexed" "t t ?"

step "4. push the multi-ABI platform version alongside the variants"
push "$BUILD_DIR/multi/$GEM-1.0.0-$PLATFORM.gem" "Successfully registered gem: $GEM (1.0.0-$PLATFORM)"
state "all three versions indexed" "t t t"

step "5. empty ruby_abi treated as absent -> yanks the multi-ABI platform version"
yank "yank ruby_abi='' + platform" 200 "Successfully deleted gem: $GEM (1.0.0-$PLATFORM)" -- \
  "gem_name=$GEM" "version=1.0.0" "platform=$PLATFORM" "ruby_abi="
state "only the multi-ABI version yanked" "t t f"

step "6. platform only, after the multi-ABI version was yanked -> 422 already deleted"
yank "yank platform only (already deleted)" 422 "has already been deleted" -- \
  "gem_name=$GEM" "version=1.0.0" "platform=$PLATFORM"
state "no change" "t t f"

step "7. targeted ABI yank -> yanks exactly that variant"
yank "yank ruby_abi=3.2" 200 "Successfully deleted gem: $GEM (1.0.0-$ADDR32, Platform: $PLATFORM, Ruby ABI 3.2)" -- \
  "gem_name=$GEM" "version=1.0.0" "platform=$PLATFORM" "ruby_abi=3.2"
state "3.2 yanked, 3.4 untouched" "f t f"

step "8. remaining variant is independently yankable"
yank "yank ruby_abi=3.4" 200 "Successfully deleted gem: $GEM (1.0.0-$ADDR34, Platform: $PLATFORM, Ruby ABI 3.4)" -- \
  "gem_name=$GEM" "version=1.0.0" "platform=$PLATFORM" "ruby_abi=3.4"
state "all three versions yanked" "f f f"

rm -rf "$BUILD_DIR"
printf '\n\033[1m%d passed, %d failed\033[0m\n' "$PASS" "$FAIL"
[[ $FAIL -eq 0 ]]
TOPHAT
```

</details>

<details>
<summary>Output (24 passed, 0 failed)</summary>

```
== Preflight: server on :3000
  PASS server is up

== Setup: user + push/yank API key + feature flag
  PASS user + key ready, CONTENT_ADDRESSABLE_GEM_PUSHES enabled

== Build: three real .gem files (same number + platform)
  PASS built skinny 3.2 / skinny 3.4 / multi-ABI

== Push: skinny variants through the real pipeline
  PASS pushed → 200: Successfully registered gem: yanktophat (1.0.0-cf3314b4, Platform: x86_64-linux-musl, Ruby ABI 3.2)
  PASS pushed → 200: Successfully registered gem: yanktophat (1.0.0-208f03e0, Platform: x86_64-linux-musl, Ruby ABI 3.4)
  PASS content addresses: cf3314b4 / 208f03e0
  PASS both variants indexed after push (abi32 abi34 multi = t t ?)

== Sanity: /info shows content-addressed lines with normalized rubygems floor
  PASS /info has 1.0.0-cf3314b4, platform:= metadata and rubygems:>= 4.1.0.beta1

== 1. ruby_abi matching no variant -> 404, nothing yanked
  PASS yank ruby_abi=3.3 → 404, body matched
  PASS both variants still indexed (abi32 abi34 multi = t t ?)

== 2. ruby_abi without platform -> 400
  PASS yank ruby_abi=3.2, no platform → 400, body matched
  PASS both variants still indexed (abi32 abi34 multi = t t ?)

== 3. platform only, when only ABI variants exist -> 404, nothing yanked
  PASS yank platform only → 404, body matched
  PASS both variants still indexed (abi32 abi34 multi = t t ?)

== 4. push the multi-ABI platform version alongside the variants
  PASS pushed → 200: Successfully registered gem: yanktophat (1.0.0-x86_64-linux-musl)
  PASS all three versions indexed (abi32 abi34 multi = t t t)

== 5. empty ruby_abi treated as absent -> yanks the multi-ABI platform version
  PASS yank ruby_abi='' + platform → 200, body matched
  PASS only the multi-ABI version yanked (abi32 abi34 multi = t t f)

== 6. platform only, after the multi-ABI version was yanked -> 422 already deleted
  PASS yank platform only (already deleted) → 422, body matched
  PASS no change (abi32 abi34 multi = t t f)

== 7. targeted ABI yank -> yanks exactly that variant
  PASS yank ruby_abi=3.2 → 200, body matched
  PASS 3.2 yanked, 3.4 untouched (abi32 abi34 multi = f t f)

== 8. remaining variant is independently yankable
  PASS yank ruby_abi=3.4 → 200, body matched
  PASS all three versions yanked (abi32 abi34 multi = f f f)

24 passed, 0 failed
```

</details>

On admin
<img width="730" height="435" alt="Screenshot 2026-08-11 at 12 29 16 PM" src="https://github.com/user-attachments/assets/919b687c-7a2a-4ebf-bc1c-7f71cec1ce3d" />

<img width="867" height="784" alt="Screenshot 2026-08-11 at 12 29 31 PM" src="https://github.com/user-attachments/assets/11881f39-b633-4596-9713-13307ca4db6d" />

