### PR TITLE
Store the content address on Version instead of parsing full_name

### DIFF
--- a/app/models/concerns/compact_index_versions.rb
+++ b/app/models/concerns/compact_index_versions.rb
@@ -9,17 +9,18 @@ module CompactIndexVersions
       checksum_column = config[:checksum_column]
       yanked_checksum_column = config[:yanked_checksum_column]
 
-      query = ["(SELECT r.name, v.created_at as date, v.#{checksum_column} as info_checksum, v.number, v.platform, v.ruby_abi, v.full_name
+      query = ["(SELECT r.name, v.created_at as date, v.#{checksum_column} as info_checksum, v.number, v.platform, v.ruby_abi, v.content_address
                 FROM rubygems AS r, versions AS v
                 WHERE v.rubygem_id = r.id AND
                       v.created_at > ?)
                 UNION
-                (SELECT r.name, v.yanked_at as date, v.#{yanked_checksum_column} as info_checksum, '-'||v.number, v.platform, v.ruby_abi, v.full_name
+                (SELECT r.name, v.yanked_at as date, v.#{yanked_checksum_column} as info_checksum, '-'||v.number,
+                        v.platform, v.ruby_abi, v.content_address
                 FROM rubygems AS r, versions AS v
                 WHERE v.rubygem_id = r.id AND
                       v.indexed is false AND
                       v.yanked_at > ?)
-                ORDER BY date, number, platform, ruby_abi, full_name, name", date, date]
+                ORDER BY date, number, platform, ruby_abi, content_address, name", date, date]
 
       map_gem_versions(execute_raw_sql(query).map { |v| [v["name"], [v]] }, version:)
     end
@@ -35,11 +36,11 @@ module CompactIndexVersions
 
       query = ["SELECT r.name, v.indexed, COALESCE(v.yanked_at, v.created_at) as stamp,
                        v.sha256, COALESCE(v.#{yanked_checksum_column}, v.#{checksum_column}) as info_checksum,
-                       v.number, v.platform, v.ruby_abi, v.full_name
+                       v.number, v.platform, v.ruby_abi, v.content_address
                 FROM rubygems AS r, versions AS v
                 WHERE v.rubygem_id = r.id AND
                       (v.created_at <= ? OR v.yanked_at <= ?)
-                ORDER BY r.name COLLATE \"C\", stamp, v.number, v.platform, v.ruby_abi, v.full_name", updated_at, updated_at]
+                ORDER BY r.name COLLATE \"C\", stamp, v.number, v.platform, v.ruby_abi, v.content_address", updated_at, updated_at]
 
       execute_raw_sql(query)
         .chunk_while { |a, b| a["name"] == b["name"] }
@@ -78,7 +79,7 @@ module CompactIndexVersions
           checksum: version_row["sha256"],
           info_checksum: version_row["info_checksum"],
           ruby_abi: version_row["ruby_abi"],
-          content_address: Version.content_address_in(version_row["full_name"], ruby_abi: version_row["ruby_abi"], platform: version_row["platform"])
+          content_address: version_row["content_address"]
         }
         args = args.slice(*version_class.members)
         version_class.new(**args)

--- a/app/models/gem_info.rb
+++ b/app/models/gem_info.rb
@@ -72,11 +72,10 @@ class GemInfo
         end
       end
 
-      number, platform, checksum, info_checksum, ruby_version, rubygems_version, created_at, ruby_abi, full_name, = row
+      number, platform, checksum, info_checksum, ruby_version, rubygems_version, created_at, ruby_abi, content_address, = row
       version_class = VERSIONS.dig(version, :klass)
       checksum = Version._sha256_hex(checksum)
       created_at = created_at&.utc&.iso8601
-      content_address = Version.content_address_in(full_name, ruby_abi:, platform:)
       args = { number:,
               platform:,
               checksum:,
@@ -101,7 +100,7 @@ class GemInfo
     checksum_column = VERSIONS.fetch(version).fetch(:checksum_column)
     group_by_columns = [
       "number", "platform", "sha256", checksum_column,
-      "required_ruby_version", "required_rubygems_version", "versions.created_at", "ruby_abi", "full_name"
+      "required_ruby_version", "required_rubygems_version", "versions.created_at", "ruby_abi", "content_address"
     ]
 
     dep_req_agg = "string_agg(dependencies.requirements, '@' ORDER BY rubygems_dependencies.name, dependencies.id)"
@@ -115,7 +114,7 @@ class GemInfo
           AND dependencies.scope = 'runtime'")
       .where("rubygems.name = ? AND versions.indexed = true", @rubygem_name)
       .group(*group_by_columns)
-      .order(Arel.sql("versions.created_at, number, platform, ruby_abi, full_name, dep_name"))
+      .order(Arel.sql("versions.created_at, number, platform, ruby_abi, content_address, dep_name"))
       .pluck(*group_by_columns, Arel.sql(dep_req_agg), Arel.sql(dep_name_agg))
   end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -21,6 +21,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_many :attestations, dependent: :destroy, inverse_of: :version
 
   before_validation :set_canonical_number, if: :number_changed?
+  before_validation :content_addressify!
   before_validation :full_nameify!
   before_validation :gem_full_nameify!
   before_save :create_link_verifications, if: :metadata_changed?
@@ -53,6 +54,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     allow_blank: true
   validates :sha256, :spec_sha256, format: { with: Patterns::BASE64_SHA256_PATTERN }, allow_nil: true
   validates :sha256, presence: true, if: :content_addressable?
+  validates :content_address, format: { with: CONTENT_ADDRESS_FORMAT }, allow_nil: true
 
   validates :number, :platform, :gem_platform, :full_name, :gem_full_name, :canonical_number,
     name_format: { requires_letter: false },
@@ -490,14 +492,6 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     platform.present? && platform != "ruby"
   end
 
-  def self.content_address_in(full_name, ruby_abi:, platform:)
-    return if full_name.blank? || ruby_abi.blank?
-    return unless platformed?(platform)
-
-    candidate = full_name.split("-").last
-    candidate if candidate&.match?(CONTENT_ADDRESS_FORMAT)
-  end
-
   def normalize_content_addressable_gem_metadata!
     return unless content_addressable?
     return if required_rubygems_version_satisfies_content_addressable_floor?
@@ -577,8 +571,12 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.gem_full_name = platform_identity(gem_platform)
   end
 
-  def content_address
-    Version.content_address_in(full_name, ruby_abi:, platform:) || generate_content_address
+  def content_addressify!
+    return if rubygem.nil?
+    return unless content_addressable?
+    return if sha256.blank?
+
+    self.content_address ||= generate_content_address
   end
 
   def generate_content_address
@@ -599,7 +597,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def platform_identity(platform_value)
-    return content_addressed_full_name if content_addressable? && sha256.present?
+    return content_addressed_full_name if content_addressable? && content_address.present?
 
     identity = "#{rubygem.name}-#{number}"
     identity << "-#{platform_value}" unless platform_value == "ruby"

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -55,6 +55,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validates :sha256, :spec_sha256, format: { with: Patterns::BASE64_SHA256_PATTERN }, allow_nil: true
   validates :sha256, presence: true, if: :content_addressable?
   validates :content_address, format: { with: CONTENT_ADDRESS_FORMAT }, allow_nil: true
+  validates :content_address, absence: true, unless: :content_addressable?
 
   validates :number, :platform, :gem_platform, :full_name, :gem_full_name, :canonical_number,
     name_format: { requires_letter: false },

--- a/db/migrate/20260809035244_add_content_address_to_versions.rb
+++ b/db/migrate/20260809035244_add_content_address_to_versions.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddContentAddressToVersions < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :versions, :content_address, :string, if_not_exists: true
+
+    add_index :versions,
+      %i[rubygem_id number content_address],
+      unique: true,
+      where: "content_address IS NOT NULL",
+      name: "index_versions_number_content_address",
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -695,6 +695,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_160835) do
     t.datetime "built_at", precision: nil
     t.string "canonical_number"
     t.text "cert_chain"
+    t.string "content_address"
     t.datetime "created_at", precision: nil
     t.text "description"
     t.string "full_name"
@@ -736,6 +737,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_160835) do
     t.index ["prerelease"], name: "index_versions_on_prerelease"
     t.index ["pusher_api_key_id"], name: "index_versions_on_pusher_api_key_id"
     t.index ["pusher_id"], name: "index_versions_on_pusher_id"
+    t.index ["rubygem_id", "number", "content_address"], name: "index_versions_number_content_address", unique: true, where: "(content_address IS NOT NULL)"
     t.index ["rubygem_id", "number", "platform", "ruby_abi"], name: "index_versions_number_platform_abi", unique: true, where: "(ruby_abi IS NOT NULL)"
     t.index ["rubygem_id", "number", "platform"], name: "index_versions_number_platform_no_abi", unique: true, where: "(ruby_abi IS NULL)"
     t.index ["rubygem_id", "position", "created_at"], name: "index_versions_on_rubygem_id_and_position_and_created_at", order: { created_at: :desc }, where: "(indexed = true)", include: ["full_name", "number", "platform"]

--- a/test/integration/api/compact_index_test.rb
+++ b/test/integration/api/compact_index_test.rb
@@ -116,7 +116,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
       ruby_abi: "3.2"
     )
 
-    content_address = version.full_name.split("-").last
+    content_address = version.content_address
 
     get versions_path
 
@@ -221,7 +221,7 @@ class Api::CompactIndexTest < ActionDispatch::IntegrationTest
       ruby_abi: "3.2"
     )
 
-    content_address = version.full_name.split("-").last
+    content_address = version.content_address
 
     expected = <<~VERSIONS_FILE
       ---

--- a/test/models/concerns/compact_index_versions_test.rb
+++ b/test/models/concerns/compact_index_versions_test.rb
@@ -27,7 +27,7 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
       gem = versions.find { |compact_index_gem| compact_index_gem.name == "skinny" }
 
       assert_equal "3.2", gem.versions.first.ruby_abi
-      assert_equal version.full_name.split("-").last, gem.versions.first.content_address
+      assert_equal version.content_address, gem.versions.first.content_address
     end
 
     should "return no content address for unplatformed versions" do
@@ -98,7 +98,7 @@ class CompactIndexVersionsTest < ActiveSupport::TestCase
       gem = versions.find { |compact_index_gem| compact_index_gem.name == "skinny-public" }
 
       assert_equal "3.2", gem.versions.first.ruby_abi
-      assert_equal version.full_name.split("-").last, gem.versions.first.content_address
+      assert_equal version.content_address, gem.versions.first.content_address
     end
 
     should "not return version updated after timestamp" do

--- a/test/models/gem_info_test.rb
+++ b/test/models/gem_info_test.rb
@@ -52,7 +52,7 @@ class GemInfoTest < ActiveSupport::TestCase
       compact_index_version = info.first
 
       assert_equal "3.2", compact_index_version.ruby_abi
-      assert_equal version.full_name.split("-").last, compact_index_version.content_address
+      assert_equal version.content_address, compact_index_version.content_address
     end
 
     should "return no content address for unplatformed versions" do

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -595,28 +595,56 @@ class VersionTest < ActiveSupport::TestCase
       end
     end
 
-    context ".content_address_in" do
-      setup do
-        @abi_args = { ruby_abi: "3.4", platform: "x86_64-linux" }
+    context "#content_addressify!" do
+      should "store the content address for versions targeting a single Ruby ABI" do
+        version = create(:version, rubygem: create(:rubygem, name: "addressed"), number: "1.0.0",
+                         platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                         required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
+                         sha256: Digest::SHA2.base64digest("addressed-1.0.0"))
+
+        assert_equal version.sha256_hex.first(Version::DEFAULT_CONTENT_ADDRESS_LENGTH), version.content_address
       end
 
-      should "extract the content address from the last segment" do
-        assert_equal "abcd1234", Version.content_address_in("foo-1.0.0-abcd1234", **@abi_args)
+      should "not store a content address for versions supporting multiple Ruby ABIs" do
+        version = create(:version, rubygem: create(:rubygem, name: "plain"), number: "1.0.0",
+                         platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                         required_ruby_version: ">= 3.2")
+
+        assert_nil version.content_address
       end
 
-      should "reject candidates that do not look like a content address" do
-        assert_nil Version.content_address_in("foo-1.0.0-x86_64-linux", **@abi_args)
-        assert_nil Version.content_address_in("foo-1.0.0", **@abi_args)
-        assert_nil Version.content_address_in(nil, **@abi_args)
+      should "not store a content address for unplatformed versions" do
+        version = create(:version, rubygem: create(:rubygem, name: "unplat"), number: "20260101",
+                         platform: "ruby", gem_platform: "ruby",
+                         required_ruby_version: "~> 3.2.0", ruby_abi: "3.2")
+
+        assert_nil version.content_address
       end
 
-      should "return nil without a Ruby ABI" do
-        assert_nil Version.content_address_in("foo-1.0.0-abcd1234", ruby_abi: nil, platform: "x86_64-linux")
+      should "not attempt to derive a content address without a rubygem" do
+        version = Version.new(number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                              ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("orphan-1.0.0"))
+
+        refute_predicate version, :valid?
+        assert_nil version.content_address
       end
 
-      should "return nil for versions without a platform" do
-        assert_nil Version.content_address_in("foo-20260101", ruby_abi: "3.4", platform: "ruby")
-        assert_nil Version.content_address_in("foo-20260101", ruby_abi: "3.4", platform: nil)
+      should "not use an assigned content address for versions that are not content addressable" do
+        version = create(:version, rubygem: create(:rubygem, name: "hijack"), number: "1.0.0",
+                         platform: "ruby", gem_platform: "ruby", content_address: "abcd1234")
+
+        assert_equal "hijack-1.0.0", version.full_name
+      end
+
+      should "reject content addresses that do not match the address format" do
+        version = build(:version, rubygem: create(:rubygem, name: "badaddr"), number: "1.0.0",
+                        platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
+                        sha256: Digest::SHA2.base64digest("badaddr-1.0.0"))
+        version.content_address = "not hex!"
+
+        refute_predicate version, :valid?
+        assert_includes version.errors[:content_address], "is invalid"
       end
     end
 
@@ -951,7 +979,7 @@ class VersionTest < ActiveSupport::TestCase
 
     should "give content address, platform and Ruby ABI for #to_title" do
       rubygem = create(:rubygem, name: "nokogiri")
-      version = build(
+      version = create(
         :version,
         rubygem: rubygem,
         number: "1.18.9",

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -629,11 +629,13 @@ class VersionTest < ActiveSupport::TestCase
         assert_nil version.content_address
       end
 
-      should "not use an assigned content address for versions that are not content addressable" do
-        version = create(:version, rubygem: create(:rubygem, name: "hijack"), number: "1.0.0",
-                         platform: "ruby", gem_platform: "ruby", content_address: "abcd1234")
+      should "be invalid when a platformed version with no ruby_abi has a content address" do
+        version = build(:version, rubygem: create(:rubygem, name: "inconsistent"), number: "1.0.0",
+                        platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                        ruby_abi: nil, content_address: "abcdef12")
 
-        assert_equal "hijack-1.0.0", version.full_name
+        refute_predicate version, :valid?
+        assert_includes version.errors[:content_address], "must be blank"
       end
 
       should "reject content addresses that do not match the address format" do


### PR DESCRIPTION
https://github.com/rubygems/rubygems.org/pull/6674

### Problem

Every component of `full_name` has its own column (`rubygems.name`, `versions.number`, `versions.platform`) — except the content address, which only existed embedded in the string. That forced two workarounds: the compact index paths re-extracted it with a hex-format heuristic (gated on ABI + platform to avoid mistaking date-style version numbers like `20260101` for addresses), and `Version#content_address` re-ran the DB uniqueness probe on every call. There was also no database-level guard against two versions of a gem computing the same identity — unique `lower(full_name)` indexes are impossible on this table (97 grandfathered case-collision groups from 2009–2010, most still live).

### Solution

Store the address in `versions.content_address`:

- `content_addressify!` (a `before_validation` alongside `full_nameify!` / `gem_full_nameify!`) runs the uniqueness probe once at push time and stores the result; `full_name` is derived from the column
- `/versions` and `/info` select the column directly — the extraction heuristic is deleted
- Format validation (`/\A[0-9a-f]{8,64}\z/`, `allow_nil`) keeps junk addresses out
- A partial unique index enforces the real invariant, mirroring the classic platform uniqueness:

### Tophat

Pushes three real `.gem` files through the pipeline (flag enabled), then verifies the column against the digest and `full_name`, the `/versions` + `/info` output, and the unique index.

Run from the repo root with the server on `:3000` — paste the whole block into your console:

<details>
<summary>Tophat script (single paste)</summary>

```bash
bash <<'TOPHAT'
set -uo pipefail

BASE_URL="${BASE_URL:-http://localhost:3000}"
GEM="catophat$(date +%s)"
PLATFORM="x86_64-linux-musl"
BUILD_DIR=$(mktemp -d)
PASS=0 FAIL=0

step() { printf '\n\033[1m== %s\033[0m\n' "$*"; }
ok()   { PASS=$((PASS+1)); printf '  \033[32mPASS\033[0m %s\n' "$*"; }
bad()  { FAIL=$((FAIL+1)); printf '  \033[31mFAIL\033[0m %s\n' "$*"; }

push() { # push <file> <expected_body_substring>
  local file="$1" want_body="$2" resp code body
  resp=$(curl -s -w $'\n%{http_code}' -X POST "$BASE_URL/api/v1/gems" \
              -H "Authorization: $KEY" -H "Content-Type: application/octet-stream" \
              --data-binary "@$file")
  code=${resp##*$'\n'}
  body=${resp%$'\n'*}
  if [[ "$code" == "200" && "$body" == *"$want_body"* ]]; then
    ok "pushed → $code: ${body:0:110}"
  else
    bad "push → got $code; body: ${body:0:150}"
  fi
}

step "Preflight: server on :3000"
curl -sf "$BASE_URL/" > /dev/null || { echo "Server not running — start it with ./.agents/skills/run-rubygems-org/smoke.sh"; exit 1; }
ok "server is up"

step "Setup: user + push API key + feature flag"
RUNNER_LOG=$(mktemp)
KEY=$(bin/rails runner "
  user = User.find_or_create_by!(handle: \"catophat\") do |u|
    u.email = \"catophat@rubygems-test.org\"
    u.password = SecureRandom.hex(16)
    u.email_confirmed = true
  end
  FeatureFlag.enable_for_actor(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, user)
  raw = SecureRandom.hex(24)
  user.api_keys.create!(name: \"catophat-#{SecureRandom.hex(4)}\",
                        hashed_key: Digest::SHA256.hexdigest(raw),
                        scopes: %w[push_rubygem])
  puts \"KEY=#{raw}\"
" 2>"$RUNNER_LOG" | grep "^KEY=" | cut -d= -f2)
if [[ -n "$KEY" ]]; then
  ok "user + key ready, CONTENT_ADDRESSABLE_GEM_PUSHES enabled"
else
  bad "setup failed — bin/rails runner output:"
  tail -15 "$RUNNER_LOG" | sed 's/^/    /'
  echo "    (common causes: wrong ruby active — .ruby-version wants $(cat .ruby-version), you have $(ruby -v 2>/dev/null | cut -d' ' -f2); or pending migrations: bin/rails db:migrate)"
  exit 1
fi

step "Build: skinny 3.2 / skinny 3.4 / multi-ABI .gem files (same number + platform)"
ruby -rrubygems/package -e '
  gem_name, platform, build_dir = ARGV
  [["skinny32", "~> 3.2.0"], ["skinny34", "~> 3.4.0"], ["multi", ">= 3.2"]].each do |label, req|
    dir = File.join(build_dir, label)
    Dir.mkdir(dir)
    spec = Gem::Specification.new do |s|
      s.name        = gem_name
      s.version     = "1.0.0"
      s.platform    = platform
      s.summary     = "content address tophat (#{label})"
      s.authors     = ["tophat"]
      s.files       = []
      s.required_ruby_version = req
    end
    Dir.chdir(dir) { Gem::Package.build(spec) }
  end
' "$GEM" "$PLATFORM" "$BUILD_DIR" > /dev/null 2>&1 \
  && ok "built in $BUILD_DIR" || { bad "gem build failed"; exit 1; }

step "Push: through the real pipeline"
push "$BUILD_DIR/skinny32/$GEM-1.0.0-$PLATFORM.gem" "Ruby ABI 3.2"
push "$BUILD_DIR/skinny34/$GEM-1.0.0-$PLATFORM.gem" "Ruby ABI 3.4"
push "$BUILD_DIR/multi/$GEM-1.0.0-$PLATFORM.gem"    "Successfully registered gem: $GEM (1.0.0-$PLATFORM)"

step "Column: content_address stored, consistent with sha256 and full_name"
CHECK=$(bin/rails runner "
  r = Rubygem.find_by!(name: \"$GEM\")
  abi32 = r.versions.find_by!(ruby_abi: \"3.2\")
  abi34 = r.versions.find_by!(ruby_abi: \"3.4\")
  multi = r.versions.find_by!(ruby_abi: nil, platform: \"$PLATFORM\")

  checks = []
  checks << (abi32.content_address == abi32.sha256_hex.first(8))
  checks << (abi32.full_name == \"#{r.name}-1.0.0-#{abi32.content_address}\")
  checks << (abi34.content_address == abi34.sha256_hex.first(8))
  checks << (multi.content_address.nil?)
  checks << (multi.full_name == \"#{r.name}-1.0.0-$PLATFORM\")
  puts \"CHECK=#{checks.all? ? 'ok' : checks.inspect}\"
  puts \"ADDR32=#{abi32.content_address}\"
  puts \"ADDR34=#{abi34.content_address}\"
" 2>/dev/null | grep -E "^(CHECK|ADDR3[24])=")
eval "$(echo "$CHECK" | grep -E '^ADDR')"
[[ "$(echo "$CHECK" | grep '^CHECK=' | cut -d= -f2)" == "ok" ]] \
  && ok "column matches digest prefix and full_name derives from it ($ADDR32 / $ADDR34); multi is NULL" \
  || bad "column state wrong: $CHECK"

step "Index: /versions and /info read the column"
VERSIONS=$(curl -s "$BASE_URL/versions")
[[ "$VERSIONS" == *"$GEM 1.0.0-$ADDR32"* || "$VERSIONS" == *", 1.0.0-$ADDR32"* || "$VERSIONS" == *"1.0.0-$ADDR32,"* ]] \
  && ok "/versions contains the 1.0.0-$ADDR32 token" \
  || bad "/versions missing token: $(echo "$VERSIONS" | grep "^$GEM " || echo 'gem line absent')"
INFO=$(curl -s "$BASE_URL/info/$GEM")
[[ "$INFO" == *"1.0.0-$ADDR32 "* && "$INFO" == *"1.0.0-$ADDR34 "* && "$INFO" == *"platform:= $PLATFORM"* && "$INFO" == *"rubygems:>= 4.1.0.beta1"* ]] \
  && ok "/info lists both content-addressed lines with platform:= and normalized rubygems floor" \
  || bad "/info unexpected: ${INFO:0:250}"

step "Unique index: duplicate (rubygem, number, content_address) rejected at the database level"
DUP=$(bin/rails runner "
  r = Rubygem.find_by!(name: \"$GEM\")
  abi32 = r.versions.find_by!(ruby_abi: \"3.2\")
  dup = r.versions.build(number: \"1.0.0\", platform: \"arm64-darwin-25\", gem_platform: \"arm64-darwin-25\",
                         authors: [\"tophat\"], description: \"dup\", ruby_abi: \"3.2\",
                         sha256: abi32.sha256, spec_sha256: abi32.spec_sha256, size: 1,
                         full_name: \"#{r.name}-1.0.0-dup\", gem_full_name: \"#{r.name}-1.0.0-dup\",
                         content_address: abi32.content_address, canonical_number: \"1.0.0\")
  begin
    dup.save!(validate: false)
    dup.destroy
    puts \"DUP=inserted\"
  rescue ActiveRecord::RecordNotUnique
    puts \"DUP=rejected\"
  end
" 2>/dev/null | grep "^DUP=" | cut -d= -f2)
[[ "$DUP" == "rejected" ]] && ok "RecordNotUnique raised for duplicate content address" \
                           || bad "duplicate insert result: $DUP"

rm -rf "$BUILD_DIR"
printf '\n\033[1m%d passed, %d failed\033[0m\n' "$PASS" "$FAIL"
[[ $FAIL -eq 0 ]]
TOPHAT
```

</details>

<details>
<summary>Output (10 passed, 0 failed)</summary>

```
== Preflight: server on :3000
  PASS server is up

== Setup: user + push API key + feature flag
  PASS user + key ready, CONTENT_ADDRESSABLE_GEM_PUSHES enabled

== Build: skinny 3.2 / skinny 3.4 / multi-ABI .gem files (same number + platform)
  PASS built

== Push: through the real pipeline
  PASS pushed → 200: Successfully registered gem: catophat (1.0.0-fffb03fb, Platform: x86_64-linux-musl, Ruby ABI 3.2)
  PASS pushed → 200: Successfully registered gem: catophat (1.0.0-c9685ae9, Platform: x86_64-linux-musl, Ruby ABI 3.4)
  PASS pushed → 200: Successfully registered gem: catophat (1.0.0-x86_64-linux-musl)

== Column: content_address stored, consistent with sha256 and full_name
  PASS column matches digest prefix and full_name derives from it (fffb03fb / c9685ae9); multi is NULL

== Index: /versions and /info read the column
  PASS /versions contains the 1.0.0-fffb03fb token
  PASS /info lists both content-addressed lines with platform:= and normalized rubygems floor

== Unique index: duplicate (rubygem, number, content_address) rejected at the database level
  PASS RecordNotUnique raised for duplicate content address

10 passed, 0 failed
```

</details>
