### PR TITLE
[Content Addressable] Ruby ABI hardening across indexes, APIs, events and admin

### DIFF
--- a/app/avo/resources/version.rb
+++ b/app/avo/resources/version.rb
@@ -34,6 +34,8 @@ class Avo::Resources::Version < Avo::BaseResource
     field :slug, as: :text, hide_on: :index
     field :number, as: :text
     field :platform, as: :text
+    field :ruby_abi, as: :text, title: "Ruby ABI"
+    field :content_address, as: :text
 
     field :canonical_number, as: :text
 

--- a/app/controllers/api/v2/contents_controller.rb
+++ b/app/controllers/api/v2/contents_controller.rb
@@ -24,8 +24,8 @@ class Api::V2::ContentsController < Api::BaseController
   protected
 
   def find_version
-    version_params = params.permit(:version_number, :platform)
-    @version = @rubygem.find_public_version(version_params[:version_number], version_params[:platform])
+    version_params = params.permit(:version_number, :platform, :ruby_abi)
+    @version = @rubygem.find_public_version(version_params[:version_number], version_params[:platform], version_params[:ruby_abi].presence)
     render plain: "This version could not be found.", status: :not_found unless @version
   end
 

--- a/app/controllers/api/v2/versions_controller.rb
+++ b/app/controllers/api/v2/versions_controller.rb
@@ -8,7 +8,7 @@ class Api::V2::VersionsController < Api::BaseController
     cache_expiry_headers
     set_surrogate_key "gem/#{@rubygem.name}"
 
-    version = @rubygem.public_version_payload(version_params[:number], version_params[:platform])
+    version = @rubygem.public_version_payload(version_params[:number], version_params[:platform], version_params[:ruby_abi].presence)
     if version
       respond_to do |format|
         format.json { render json: version }
@@ -22,6 +22,6 @@ class Api::V2::VersionsController < Api::BaseController
   protected
 
   def version_params
-    params.permit(:platform, :number)
+    params.permit(:platform, :number, :ruby_abi)
   end
 end

--- a/app/models/events/rubygem_event.rb
+++ b/app/models/events/rubygem_event.rb
@@ -8,6 +8,7 @@ class Events::RubygemEvent < ApplicationRecord
   VERSION_PUSHED = define_event "rubygem:version:pushed" do
     attribute :number, :string
     attribute :platform, :string
+    attribute :ruby_abi, :string
     attribute :sha256, :string
 
     attribute :pushed_by, :string

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -186,16 +186,16 @@ class Rubygem < ApplicationRecord
 
   # NB: this intentionally does not default the platform to ruby.
   # Without platform, finds the most recent version by (position, created_at) ignoring platform.
-  def find_public_version(number, platform = nil)
+  def find_public_version(number, platform = nil, ruby_abi = nil)
     if platform
-      public_versions.find_by(number:, platform:)
+      public_versions.find_by(number:, platform:, ruby_abi:)
     else
       public_versions.find_by(number:)
     end
   end
 
-  def public_version_payload(number, platform = nil)
-    version = find_public_version(number, platform)
+  def public_version_payload(number, platform = nil, ruby_abi = nil)
+    version = find_public_version(number, platform, ruby_abi)
     payload(version).merge!(version.as_json) if version
   end
 

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -263,6 +263,7 @@ class Rubygem < ApplicationRecord
       "version_created_at" => version.created_at,
       "version_downloads"  => version.downloads_count,
       "platform"           => version.platform,
+      "ruby_abi"           => version.ruby_abi,
       "authors"            => version.authors,
       "info"               => version.info,
       "licenses"           => version.licenses,

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -661,8 +661,8 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def record_push_event
-    rubygem.record_event!(Events::RubygemEvent::VERSION_PUSHED, number: number, platform: platform, sha256: sha256_hex,
-      pushed_by: pusher&.display_handle, version_gid: to_gid, actor_gid: pusher&.to_gid)
+    rubygem.record_event!(Events::RubygemEvent::VERSION_PUSHED, number: number, platform: platform, ruby_abi: ruby_abi,
+      sha256: sha256_hex, pushed_by: pusher&.display_handle, version_gid: to_gid, actor_gid: pusher&.to_gid)
   end
 
   def enqueue_web_hook_jobs

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -147,6 +147,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     joins(:rubygem)
       .indexed
       .release
+      .where(ruby_abi: nil)
       .order("rubygems.name asc, position desc")
       .pluck("rubygems.name", :number, :platform)
   end
@@ -155,6 +156,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     joins(:rubygem)
       .indexed
       .latest
+      .where(ruby_abi: nil)
       .order("rubygems.name asc, position desc")
       .pluck("rubygems.name", :number, :platform)
   end
@@ -163,6 +165,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
     joins(:rubygem)
       .indexed
       .prerelease
+      .where(ruby_abi: nil)
       .order("rubygems.name asc, position desc")
       .pluck("rubygems.name", :number, :platform)
   end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -370,6 +370,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
       "rubygems_version"           => required_rubygems_version,
       "ruby_version"               => required_ruby_version,
       "prerelease"                 => prerelease,
+      "ruby_abi"                   => ruby_abi,
       "licenses"                   => licenses,
       "requirements"               => requirements,
       "sha"                        => sha256_hex,

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -56,6 +56,7 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   validates :sha256, presence: true, if: :content_addressable?
   validates :content_address, format: { with: CONTENT_ADDRESS_FORMAT }, allow_nil: true
   validates :content_address, absence: true, unless: :content_addressable?
+  validates :ruby_abi, format: { with: /\A\d+\.\d+\z/ }, allow_nil: true
 
   validates :number, :platform, :gem_platform, :full_name, :gem_full_name, :canonical_number,
     name_format: { requires_letter: false },

--- a/app/views/components/events/rubygem_event/version/pushed_component.rb
+++ b/app/views/components/events/rubygem_event/version/pushed_component.rb
@@ -6,7 +6,7 @@ class Events::RubygemEvent::Version::PushedComponent < Events::TableDetailsCompo
   def view_template
     div do
       t(".version_html", version:
-        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform))
+        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform, additional.ruby_abi))
     end
     if additional.sha256.present?
       sha256 = capture { code(class: "tw-break-all") { additional.sha256 } }

--- a/app/views/components/events/rubygem_event/version/unyanked_component.rb
+++ b/app/views/components/events/rubygem_event/version/unyanked_component.rb
@@ -2,6 +2,6 @@
 
 class Events::RubygemEvent::Version::UnyankedComponent < Events::TableDetailsComponent
   def view_template
-    raw t(".version_html", version: link_to_version_from_gid(additional.version_gid, additional.number, additional.platform))
+    raw t(".version_html", version: link_to_version_from_gid(additional.version_gid, additional.number, additional.platform, additional.ruby_abi))
   end
 end

--- a/app/views/components/events/rubygem_event/version/yank_forbidden_component.rb
+++ b/app/views/components/events/rubygem_event/version/yank_forbidden_component.rb
@@ -4,7 +4,7 @@ class Events::RubygemEvent::Version::YankForbiddenComponent < Events::TableDetai
   def view_template
     div do
       t(".version_html", version:
-        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform))
+        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform, additional.ruby_abi))
     end
     return if additional.yanked_by.blank?
     div do

--- a/app/views/components/events/rubygem_event/version/yanked_component.rb
+++ b/app/views/components/events/rubygem_event/version/yanked_component.rb
@@ -4,7 +4,7 @@ class Events::RubygemEvent::Version::YankedComponent < Events::TableDetailsCompo
   def view_template
     div do
       t(".version_html", version:
-        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform))
+        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform, additional.ruby_abi))
     end
     return if additional.yanked_by.blank?
     div do

--- a/app/views/components/events/table_details_component.rb
+++ b/app/views/components/events/table_details_component.rb
@@ -26,13 +26,16 @@ class Events::TableDetailsComponent < ApplicationComponent
     end
   end
 
-  def link_to_version_from_gid(gid, number, platform)
+  def link_to_version_from_gid(gid, number, platform, ruby_abi = nil)
     version = load_gid(gid, only: Version)
 
     if version
       view_context.link_to version.to_title, rubygem_version_path(version.rubygem.slug, version.slug)
     else
-      "#{rubygem.name} (#{number}#{"-#{platform}" unless platform.blank? || platform == 'ruby'})"
+      title = "#{rubygem.name} (#{number}#{"-#{platform}" unless platform.blank? || platform == 'ruby'}"
+      title << ", Ruby ABI #{ruby_abi}" if ruby_abi.present?
+      title << ")"
+      title
     end
   end
 

--- a/test/functional/api/v2/versions_controller_test.rb
+++ b/test/functional/api/v2/versions_controller_test.rb
@@ -219,7 +219,7 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
       assert_equal(
         %w[
           name downloads version version_created_at version_downloads platform
-          authors info licenses metadata yanked sha spec_sha project_uri gem_uri
+          ruby_abi authors info licenses metadata yanked sha spec_sha project_uri gem_uri
           homepage_uri wiki_uri documentation_uri mailing_list_uri
           source_code_uri bug_tracker_uri changelog_uri funding_uri dependencies
           built_at created_at description downloads_count number summary

--- a/test/functional/api/v2/versions_controller_test.rb
+++ b/test/functional/api/v2/versions_controller_test.rb
@@ -68,6 +68,45 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
       create(:version, rubygem: @rubygem2, number: "1.0.0")
     end
 
+    context "with versions across Ruby ABIs" do
+      setup do
+        @rubygem = create(:rubygem, name: "sandworm")
+        @abi32 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.2"))
+        @abi34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.4"))
+        @multi = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: ">= 3.2", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-multi"),
+                        spec_sha256: Digest::SHA2.base64digest("spec-multi"))
+      end
+
+      should "return the targeted Ruby ABI variant when ruby_abi is given" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.2", format: "json" }
+
+        assert_response :success
+        payload = JSON.parse(@response.body)
+
+        assert_equal "3.2", payload["ruby_abi"]
+        assert_equal @abi32.sha256_hex, payload["sha"]
+      end
+
+      should "return the version supporting multiple Ruby ABIs without a ruby_abi param" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", platform: "x86_64-linux-musl", format: "json" }
+
+        assert_response :success
+        payload = JSON.parse(@response.body)
+
+        assert_nil payload["ruby_abi"]
+        assert_equal @multi.sha256_hex, payload["sha"]
+      end
+
+      should "return not found for a ruby_abi that does not match any variant" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.3", format: "json" }
+
+        assert_response :not_found
+      end
+    end
+
     should_respond_to(:json) do |body|
       JSON.parse(body)
     end

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -550,6 +550,7 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal @rubygem.most_recent_version.created_at.as_json, hash["version_created_at"]
       assert_equal @rubygem.most_recent_version.downloads_count, hash["version_downloads"]
       assert_equal @rubygem.most_recent_version.platform, hash["platform"]
+      assert_nil hash.fetch("ruby_abi")
       assert_equal @rubygem.most_recent_version.authors, hash["authors"]
       assert_equal @rubygem.most_recent_version.info, hash["info"]
       assert_equal @rubygem.most_recent_version.metadata, hash["metadata"]

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -15,7 +15,7 @@ class VersionTest < ActiveSupport::TestCase
       json = @version.as_json
 
       fields = %w[number built_at summary description authors platform
-                  ruby_version rubygems_version prerelease downloads_count licenses
+                  ruby_version rubygems_version prerelease ruby_abi downloads_count licenses
                   requirements sha spec_sha metadata created_at]
 
       assert_equal fields.sort, json.keys.sort
@@ -44,7 +44,7 @@ class VersionTest < ActiveSupport::TestCase
     should "only have relevant API fields" do
       xml = Nokogiri.parse(@version.to_xml)
       fields = %w[number built-at summary description authors platform
-                  ruby-version rubygems-version prerelease downloads-count licenses
+                  ruby-version rubygems-version prerelease ruby-abi downloads-count licenses
                   requirements sha spec-sha metadata created-at]
 
       assert_equal fields.map(&:to_s).sort,

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -1342,6 +1342,14 @@ class VersionTest < ActiveSupport::TestCase
         number: "0.0.2.pre",
         platform: "java",
         prerelease: true)
+      @content_addressable_version = create(:version,
+        rubygem: @second_rubygem,
+        number: "0.0.2",
+        platform: "x86_64-linux-musl",
+        gem_platform: "x86_64-linux-musl",
+        required_ruby_version: "~> 3.4.0",
+        ruby_abi: "3.4",
+        sha256: Digest::SHA2.base64digest("second-0.0.2-x86_64-linux-musl"))
     end
 
     should "select only name, version, and platform for all gems" do

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -159,6 +159,17 @@ class VersionTest < ActiveSupport::TestCase
       refute_predicate @dup_version, :valid?
     end
 
+    should "record the Ruby ABI on the pushed version event" do
+      version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                       required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
+                       sha256: Digest::SHA2.base64digest("abi-event-1.0.0"))
+
+      pushed = @rubygem.events.where(tag: Events::RubygemEvent::VERSION_PUSHED).sole
+
+      assert_equal "3.4", pushed.additional.ruby_abi
+      assert_equal version.sha256_hex, pushed.additional.sha256
+    end
+
     should "not allow a ruby_abi that is not a Ruby minor version" do
       version = build(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
                       required_ruby_version: "~> 3.4.0", ruby_abi: "banana",

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -159,6 +159,15 @@ class VersionTest < ActiveSupport::TestCase
       refute_predicate @dup_version, :valid?
     end
 
+    should "not allow a ruby_abi that is not a Ruby minor version" do
+      version = build(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                      required_ruby_version: "~> 3.4.0", ruby_abi: "banana",
+                      sha256: Digest::SHA2.base64digest("abi-format-1.0.0"))
+
+      refute_predicate version, :valid?
+      assert_includes version.errors[:ruby_abi], "is invalid"
+    end
+
     should "allow duplicate versions with different Ruby ABIs" do
       existing_version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "arm64-darwin-25",
         required_ruby_version: "~> 3.3.0", ruby_abi: "3.3")


### PR DESCRIPTION
https://github.com/rubygems/rubygems.org/pull/6674

Follow-ups from the deep review of the content-addressable feature, one concern per commit:

### Exclude content-addressable versions from the legacy Marshal indexes

Multiple Ruby ABI variants share a number and platform, so `specs.4.8.gz` / `latest_specs.4.8.gz` gained duplicate `(name, number, platform)` rows (worse in latest, where every variant is marked latest). Legacy clients can't install these gems anyway — the `required_rubygems_version` floor rejects them, and resolving the legacy entry constructs a platform-based download path while the file is stored content-addressed → 404 mid-install. ABI versions are now excluded from all three legacy index queries.

### Expose `ruby_abi` in the version and rubygem payloads

API consumers and webhook receivers could not distinguish ABI variants — they appeared as identical entries differing only in `sha`. Adds `ruby_abi` to `Version#payload` (`/api/v1/versions`, the v2 version endpoint) and to `Rubygem#payload`, which feeds `/api/v1/gems` and the push/yank webhooks. Additive JSON/XML field.

### Validate the `ruby_abi` format

The push path derives `ruby_abi` server-side and can only produce `X.Y`, but console sessions and backfills could persist arbitrary strings that would flow into the compact index and version identities. Same defense-in-depth as the `sha256` and `content_address` format validations.

### Allow resolving a specific Ruby ABI variant in the v2 API

`Rubygem#find_public_version` resolved by number and platform only, so the v2 **version** and **contents** endpoints returned an arbitrary variant when multiple ABI builds coexist (contents especially matters — variants have different files). Accepts a `ruby_abi` param, nil-scoped by default so existing lookups are unchanged, matching the deletions API semantics.

### Record the Ruby ABI on the pushed version event

The yank/unyank/yank-forbidden events carry the ABI for auditing; the pushed event only had `sha256` to distinguish variants. Records it there too for symmetric auditing.

### Display the Ruby ABI for deleted versions in events and Avo

Event rows render `to_title` (already ABI-aware) when the version exists, but the fallback text for hard-deleted versions was number+platform only, making yanked ABI variants indistinguishable in the gem history. The fallback now includes the ABI, and the Avo Version resource surfaces `ruby_abi` and `content_address` (Deletion already shows its ABI).

### Tophat

Pushes two ABI variants and a multi-ABI version through the real pipeline, then verifies every change in this PR: legacy index exclusion, v1/v2 payloads, v2 variant resolution, pushed events, and format validation.

Run from the repo root with the server on `:3000` — paste the whole block into your console:

<details>
<summary>Tophat script (single paste)</summary>

```bash
bash <<'TOPHAT'
set -uo pipefail

BASE_URL="${BASE_URL:-http://localhost:3000}"
GEM="hardtophat$(date +%s)"
PLATFORM="x86_64-linux-musl"
BUILD_DIR=$(mktemp -d)
PASS=0 FAIL=0

step() { printf '\n\033[1m== %s\033[0m\n' "$*"; }
ok()   { PASS=$((PASS+1)); printf '  \033[32mPASS\033[0m %s\n' "$*"; }
bad()  { FAIL=$((FAIL+1)); printf '  \033[31mFAIL\033[0m %s\n' "$*"; }

runner() { bin/rails runner "$1" 2>/dev/null | grep "^OUT=" | cut -d= -f2-; }

step "Preflight: server on :3000"
curl -sf "$BASE_URL/" > /dev/null || { echo "Server not running — start it with ./.agents/skills/run-rubygems-org/smoke.sh"; exit 1; }
ok "server is up"

step "Setup: user + push API key + feature flag"
KEY=$(runner "
  user = User.find_or_create_by!(handle: \"hardtophat\") do |u|
    u.email = \"hardtophat@rubygems-test.org\"
    u.password = SecureRandom.hex(16)
    u.email_confirmed = true
  end
  FeatureFlag.enable_for_actor(FeatureFlag::CONTENT_ADDRESSABLE_GEM_PUSHES, user)
  raw = SecureRandom.hex(24)
  user.api_keys.create!(name: \"hard-#{SecureRandom.hex(4)}\", hashed_key: Digest::SHA256.hexdigest(raw), scopes: %w[push_rubygem])
  puts \"OUT=#{raw}\"")
[[ -n "$KEY" ]] && ok "ready" || { bad "setup failed — run bin/rails runner manually to see the error"; exit 1; }

step "Push: two ABI variants + one version supporting multiple Ruby ABIs"
ruby -rrubygems/package -e '
  gem_name, platform, build_dir = ARGV
  [["skinny32", "~> 3.2.0"], ["skinny34", "~> 3.4.0"], ["multi", ">= 3.2"]].each do |label, req|
    dir = File.join(build_dir, label); Dir.mkdir(dir)
    spec = Gem::Specification.new do |s|
      s.name = gem_name; s.version = "1.0.0"; s.platform = platform
      s.summary = "hardening tophat (#{label})"; s.authors = ["tophat"]; s.files = []
      s.required_ruby_version = req
    end
    Dir.chdir(dir) { Gem::Package.build(spec) }
  end' "$GEM" "$PLATFORM" "$BUILD_DIR" > /dev/null 2>&1
for f in skinny32 skinny34 multi; do
  CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE_URL/api/v1/gems" -H "Authorization: $KEY" \
              -H "Content-Type: application/octet-stream" --data-binary "@$BUILD_DIR/$f/$GEM-1.0.0-$PLATFORM.gem")
  [[ "$CODE" == "200" ]] && ok "pushed $f" || bad "push $f → $CODE"
done

step "Legacy Marshal indexes exclude the ABI variants"
ROWS=$(runner "
  r = Rubygem.find_by!(name: \"$GEM\")
  idx = Version.rows_for_index.select { |row| row[0] == r.name }
  latest = Version.rows_for_latest_index.select { |row| row[0] == r.name }
  puts \"OUT=#{idx.length},#{latest.length}\"")
[[ "$ROWS" == "1,1" ]] && ok "exactly one legacy row (the multi-ABI version) in specs + latest indexes" \
                       || bad "legacy index rows (specs,latest) = $ROWS, want 1,1"

step "ruby_abi exposed in the version and rubygem payloads"
V1=$(curl -s "$BASE_URL/api/v1/versions/$GEM.json")
echo "$V1" | ruby -rjson -e 'abis = JSON.parse(STDIN.read).map { |v| v["ruby_abi"] }.sort_by(&:to_s); exit(abis == [nil, "3.2", "3.4"].sort_by(&:to_s) ? 0 : 1)' \
  && ok "/api/v1/versions lists ruby_abi [nil, 3.2, 3.4]" || bad "/api/v1/versions payload: $(echo "$V1" | head -c 120)"
G1=$(curl -s "$BASE_URL/api/v1/gems/$GEM.json")
echo "$G1" | ruby -rjson -e 'exit(JSON.parse(STDIN.read).key?("ruby_abi") ? 0 : 1)' \
  && ok "/api/v1/gems payload (feeds webhooks) has the ruby_abi key" || bad "/api/v1/gems payload missing ruby_abi"

step "v2 API resolves a specific Ruby ABI variant"
for want in "3.2 200" "3.4 200" "3.3 404"; do
  abi=${want% *}; code=${want#* }
  GOT=$(curl -s -o /tmp/v2body -w "%{http_code}" "$BASE_URL/api/v2/rubygems/$GEM/versions/1.0.0.json?platform=$PLATFORM&ruby_abi=$abi")
  if [[ "$GOT" == "$code" ]]; then
    if [[ "$code" == "200" ]]; then
      ruby -rjson -e 'exit(JSON.parse(File.read("/tmp/v2body"))["ruby_abi"] == ARGV[0] ? 0 : 1)' "$abi" \
        && ok "v2 ruby_abi=$abi → 200 with matching payload" || bad "v2 ruby_abi=$abi payload mismatch"
    else
      ok "v2 ruby_abi=$abi → 404"
    fi
  else
    bad "v2 ruby_abi=$abi → $GOT, want $code"
  fi
done
GOT=$(curl -s "$BASE_URL/api/v2/rubygems/$GEM/versions/1.0.0.json?platform=$PLATFORM")
echo "$GOT" | ruby -rjson -e 'exit(JSON.parse(STDIN.read)["ruby_abi"].nil? ? 0 : 1)' \
  && ok "v2 without ruby_abi resolves the multi-ABI version" || bad "v2 default resolution: $(echo "$GOT" | head -c 100)"

step "Pushed events carry the Ruby ABI"
EV=$(runner "
  r = Rubygem.find_by!(name: \"$GEM\")
  abis = r.events.where(tag: Events::RubygemEvent::VERSION_PUSHED).map { |e| e.additional.ruby_abi }.sort_by(&:to_s)
  puts \"OUT=#{abis.inspect}\"")
[[ "$EV" == '[nil, "3.2", "3.4"]' ]] && ok "three VERSION_PUSHED events with ruby_abi [nil, 3.2, 3.4]" \
                                     || bad "pushed event abis: $EV"

step "ruby_abi format is validated"
VAL=$(runner "
  v = Version.new(ruby_abi: \"banana\")
  v.valid?
  puts \"OUT=#{v.errors[:ruby_abi].first}\"")
[[ "$VAL" == "is invalid" ]] && ok "ruby_abi: \"banana\" is rejected" || bad "format validation: $VAL"

rm -rf "$BUILD_DIR"
printf '\n\033[1m%d passed, %d failed\033[0m\n' "$PASS" "$FAIL"
echo "Manual check: /admin/resources/versions shows Ruby ABI + content address columns for $GEM"
[[ $FAIL -eq 0 ]]
TOPHAT
```

</details>

<details>
<summary>Output (14 passed, 0 failed)</summary>

```
== Preflight: server on :3000
  PASS server is up
== Setup: user + push API key + feature flag
  PASS ready
== Push: two ABI variants + one version supporting multiple Ruby ABIs
  PASS pushed skinny32 / skinny34 / multi
== Legacy Marshal indexes exclude the ABI variants
  PASS exactly one legacy row (the multi-ABI version) in specs + latest indexes
== ruby_abi exposed in the version and rubygem payloads
  PASS /api/v1/versions lists ruby_abi [nil, 3.2, 3.4]
  PASS /api/v1/gems payload (feeds webhooks) has the ruby_abi key
== v2 API resolves a specific Ruby ABI variant
  PASS v2 ruby_abi=3.2 → 200 with matching payload
  PASS v2 ruby_abi=3.4 → 200 with matching payload
  PASS v2 ruby_abi=3.3 → 404
  PASS v2 without ruby_abi resolves the multi-ABI version
== Pushed events carry the Ruby ABI
  PASS three VERSION_PUSHED events with ruby_abi [nil, 3.2, 3.4]
== ruby_abi format is validated
  PASS ruby_abi: "banana" is rejected
14 passed, 0 failed
```

</details>

Avo display is a manual check: `/admin/resources/versions` shows the **Ruby ABI** and **content address** columns for the tophat gem's versions.
