### PR TITLE
Link version navigation by slug so platformed variants resolve

### DIFF
--- a/app/avo/resources/deletion.rb
+++ b/app/avo/resources/deletion.rb
@@ -10,6 +10,7 @@ class Avo::Resources::Deletion < Avo::BaseResource
     field :rubygem, as: :text
     field :number, as: :text
     field :platform, as: :text
+    field :ruby_abi, as: :text, title: "Ruby ABI"
     field :user, as: :belongs_to
     field :version, as: :belongs_to
   end

--- a/app/avo/resources/version.rb
+++ b/app/avo/resources/version.rb
@@ -34,6 +34,8 @@ class Avo::Resources::Version < Avo::BaseResource
     field :slug, as: :text, hide_on: :index
     field :number, as: :text
     field :platform, as: :text
+    field :ruby_abi, as: :text, title: "Ruby ABI"
+    field :content_address, as: :text
 
     field :canonical_number, as: :text
 

--- a/app/controllers/api/v1/deletions_controller.rb
+++ b/app/controllers/api/v1/deletions_controller.rb
@@ -40,9 +40,17 @@ class Api::V1::DeletionsController < Api::BaseController
       begin
         version = params.expect(:version)
         platform = params.permit(:platform).fetch(:platform, nil)
-        @version = @rubygem.find_version!(number: version, platform: platform)
+        ruby_abi = params.permit(:ruby_abi).fetch(:ruby_abi, nil).presence
+
+        if ruby_abi.present? && platform.blank?
+          return render plain: response_with_mfa_warning("The platform param is required when ruby_abi is specified."),
+                        status: :bad_request
+        end
+
+        @version = @rubygem.find_version!(number: version, platform: platform, ruby_abi: ruby_abi)
       rescue ActiveRecord::RecordNotFound
-        render plain: response_with_mfa_warning("The version #{version}#{" (#{platform})" if platform.present?} does not exist."),
+        details = "#{" (#{platform})" if platform.present?}#{" (Ruby ABI #{ruby_abi})" if ruby_abi.present?}"
+        render plain: response_with_mfa_warning("The version #{version}#{details} does not exist."),
                status: :not_found
       end
     end

--- a/app/controllers/api/v2/contents_controller.rb
+++ b/app/controllers/api/v2/contents_controller.rb
@@ -24,8 +24,8 @@ class Api::V2::ContentsController < Api::BaseController
   protected
 
   def find_version
-    version_params = params.permit(:version_number, :platform)
-    @version = @rubygem.find_public_version(version_params[:version_number], version_params[:platform])
+    version_params = params.permit(:version_number, :platform, :ruby_abi)
+    @version = @rubygem.find_public_version(version_params[:version_number], version_params[:platform], version_params[:ruby_abi].presence)
     render plain: "This version could not be found.", status: :not_found unless @version
   end
 

--- a/app/controllers/api/v2/versions_controller.rb
+++ b/app/controllers/api/v2/versions_controller.rb
@@ -8,7 +8,7 @@ class Api::V2::VersionsController < Api::BaseController
     cache_expiry_headers
     set_surrogate_key "gem/#{@rubygem.name}"
 
-    version = @rubygem.public_version_payload(version_params[:number], version_params[:platform])
+    version = @rubygem.public_version_payload(version_params[:number], version_params[:platform], version_params[:ruby_abi].presence)
     if version
       respond_to do |format|
         format.json { render json: version }
@@ -22,6 +22,6 @@ class Api::V2::VersionsController < Api::BaseController
   protected
 
   def version_params
-    params.permit(:platform, :number)
+    params.permit(:platform, :number, :ruby_abi)
   end
 end

--- a/app/models/deletion.rb
+++ b/app/models/deletion.rb
@@ -54,6 +54,7 @@ class Deletion < ApplicationRecord
       reason: ineligible_reason,
       number: version.number,
       platform: version.platform,
+      ruby_abi: version.ruby_abi,
       yanked_by: user.display_handle,
       actor_gid: user.to_gid,
       version_gid: version.to_gid
@@ -75,6 +76,7 @@ class Deletion < ApplicationRecord
     errors.add(:rubygem, "does not match version rubygem name") unless rubygem == version.rubygem.name
     errors.add(:number, "does not match version number") unless number == version.number
     errors.add(:platform, "does not match version platform") unless platform == version.platform
+    errors.add(:ruby_abi, "does not match version Ruby ABI") unless ruby_abi == version.ruby_abi
   end
 
   def rubygem_name
@@ -85,6 +87,7 @@ class Deletion < ApplicationRecord
     self.rubygem = rubygem_name
     self.number = version.number
     self.platform = version.platform
+    self.ruby_abi = version.ruby_abi
   end
 
   def expire_cache
@@ -155,11 +158,11 @@ class Deletion < ApplicationRecord
 
   def record_yank_event
     version.rubygem.record_event!(Events::RubygemEvent::VERSION_YANKED, number: version.number, platform: version.platform,
-yanked_by: user&.display_handle, actor_gid: user&.to_gid, version_gid: version.to_gid, force:)
+ruby_abi: version.ruby_abi, yanked_by: user&.display_handle, actor_gid: user&.to_gid, version_gid: version.to_gid, force:)
   end
 
   def record_unyank_event
     version.rubygem.record_event!(Events::RubygemEvent::VERSION_UNYANKED, number: version.number, platform: version.platform,
-version_gid: version.to_gid)
+ruby_abi: version.ruby_abi, version_gid: version.to_gid)
   end
 end

--- a/app/models/events/rubygem_event.rb
+++ b/app/models/events/rubygem_event.rb
@@ -19,6 +19,7 @@ class Events::RubygemEvent < ApplicationRecord
   VERSION_YANKED = define_event "rubygem:version:yanked" do
     attribute :number, :string
     attribute :platform, :string
+    attribute :ruby_abi, :string
 
     attribute :yanked_by, :string
 
@@ -30,6 +31,7 @@ class Events::RubygemEvent < ApplicationRecord
   VERSION_YANK_FORBIDDEN = define_event "rubygem:version:yank_forbidden" do
     attribute :number, :string
     attribute :platform, :string
+    attribute :ruby_abi, :string
 
     attribute :yanked_by, :string
 
@@ -41,6 +43,7 @@ class Events::RubygemEvent < ApplicationRecord
   VERSION_UNYANKED = define_event "rubygem:version:unyanked" do
     attribute :number, :string
     attribute :platform, :string
+    attribute :ruby_abi, :string
 
     attribute :version_gid, :global_id
   end

--- a/app/models/events/rubygem_event.rb
+++ b/app/models/events/rubygem_event.rb
@@ -8,6 +8,7 @@ class Events::RubygemEvent < ApplicationRecord
   VERSION_PUSHED = define_event "rubygem:version:pushed" do
     attribute :number, :string
     attribute :platform, :string
+    attribute :ruby_abi, :string
     attribute :sha256, :string
 
     attribute :pushed_by, :string

--- a/app/models/rubygem.rb
+++ b/app/models/rubygem.rb
@@ -186,22 +186,22 @@ class Rubygem < ApplicationRecord
 
   # NB: this intentionally does not default the platform to ruby.
   # Without platform, finds the most recent version by (position, created_at) ignoring platform.
-  def find_public_version(number, platform = nil)
+  def find_public_version(number, platform = nil, ruby_abi = nil)
     if platform
-      public_versions.find_by(number:, platform:)
+      public_versions.find_by(number:, platform:, ruby_abi:)
     else
       public_versions.find_by(number:)
     end
   end
 
-  def public_version_payload(number, platform = nil)
-    version = find_public_version(number, platform)
+  def public_version_payload(number, platform = nil, ruby_abi = nil)
+    version = find_public_version(number, platform, ruby_abi)
     payload(version).merge!(version.as_json) if version
   end
 
-  def find_version!(number:, platform:)
+  def find_version!(number:, platform:, ruby_abi: nil)
     platform = platform.presence || "ruby"
-    versions.find_by!(number: number, platform: platform)
+    versions.find_by!(number: number, platform: platform, ruby_abi: ruby_abi)
   end
 
   def find_version_by_slug!(slug)

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -661,8 +661,8 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def record_push_event
-    rubygem.record_event!(Events::RubygemEvent::VERSION_PUSHED, number: number, platform: platform, sha256: sha256_hex,
-      pushed_by: pusher&.display_handle, version_gid: to_gid, actor_gid: pusher&.to_gid)
+    rubygem.record_event!(Events::RubygemEvent::VERSION_PUSHED, number: number, platform: platform, ruby_abi: ruby_abi,
+      sha256: sha256_hex, pushed_by: pusher&.display_handle, version_gid: to_gid, actor_gid: pusher&.to_gid)
   end
 
   def enqueue_web_hook_jobs

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -264,11 +264,11 @@ class Version < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def previous
-    rubygem.versions.find_by(position: position + 1)
+    rubygem.versions.where(position: position + 1).order(:id).first
   end
 
   def next
-    rubygem.versions.find_by(position: position - 1)
+    rubygem.versions.where(position: position - 1).order(:id).first
   end
 
   def yanked?

--- a/app/views/components/events/rubygem_event/version/pushed_component.rb
+++ b/app/views/components/events/rubygem_event/version/pushed_component.rb
@@ -6,7 +6,7 @@ class Events::RubygemEvent::Version::PushedComponent < Events::TableDetailsCompo
   def view_template
     div do
       t(".version_html", version:
-        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform))
+        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform, additional.ruby_abi))
     end
     if additional.sha256.present?
       sha256 = capture { code(class: "tw-break-all") { additional.sha256 } }

--- a/app/views/components/events/rubygem_event/version/unyanked_component.rb
+++ b/app/views/components/events/rubygem_event/version/unyanked_component.rb
@@ -2,6 +2,6 @@
 
 class Events::RubygemEvent::Version::UnyankedComponent < Events::TableDetailsComponent
   def view_template
-    raw t(".version_html", version: link_to_version_from_gid(additional.version_gid, additional.number, additional.platform))
+    raw t(".version_html", version: link_to_version_from_gid(additional.version_gid, additional.number, additional.platform, additional.ruby_abi))
   end
 end

--- a/app/views/components/events/rubygem_event/version/yank_forbidden_component.rb
+++ b/app/views/components/events/rubygem_event/version/yank_forbidden_component.rb
@@ -4,7 +4,7 @@ class Events::RubygemEvent::Version::YankForbiddenComponent < Events::TableDetai
   def view_template
     div do
       t(".version_html", version:
-        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform))
+        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform, additional.ruby_abi))
     end
     return if additional.yanked_by.blank?
     div do

--- a/app/views/components/events/rubygem_event/version/yanked_component.rb
+++ b/app/views/components/events/rubygem_event/version/yanked_component.rb
@@ -4,7 +4,7 @@ class Events::RubygemEvent::Version::YankedComponent < Events::TableDetailsCompo
   def view_template
     div do
       t(".version_html", version:
-        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform))
+        link_to_version_from_gid(additional.version_gid, additional.number, additional.platform, additional.ruby_abi))
     end
     return if additional.yanked_by.blank?
     div do

--- a/app/views/components/events/table_details_component.rb
+++ b/app/views/components/events/table_details_component.rb
@@ -26,13 +26,16 @@ class Events::TableDetailsComponent < ApplicationComponent
     end
   end
 
-  def link_to_version_from_gid(gid, number, platform)
+  def link_to_version_from_gid(gid, number, platform, ruby_abi = nil)
     version = load_gid(gid, only: Version)
 
     if version
       view_context.link_to version.to_title, rubygem_version_path(version.rubygem.slug, version.slug)
     else
-      "#{rubygem.name} (#{number}#{"-#{platform}" unless platform.blank? || platform == 'ruby'})"
+      title = "#{rubygem.name} (#{number}#{"-#{platform}" unless platform.blank? || platform == 'ruby'}"
+      title << ", Ruby ABI #{ruby_abi}" if ruby_abi.present?
+      title << ")"
+      title
     end
   end
 

--- a/app/views/rubygems/_version_navigation.html.erb
+++ b/app/views/rubygems/_version_navigation.html.erb
@@ -1,11 +1,11 @@
 <div class="gem__navigation flex flex-wrap justify-between gap-4 border-t border-neutral-200 dark:border-neutral-800 pt-6">
   <% if latest_version.previous.present? %>
-    <%= link_to t(".previous_version"), rubygem_version_path(rubygem.slug, latest_version.previous.number),
+    <%= link_to t(".previous_version"), rubygem_version_path(rubygem.slug, latest_version.previous.slug),
           class: "gem__previous__version text-b3 text-orange-500 hover:text-orange-600 dark:text-orange-400 dark:hover:text-orange-300" %>
   <% end %>
 
   <% if latest_version.next.present? %>
-    <%= link_to t(".next_version"), rubygem_version_path(rubygem.slug, latest_version.next.number),
+    <%= link_to t(".next_version"), rubygem_version_path(rubygem.slug, latest_version.next.slug),
           class: "gem__next__version ml-auto text-b3 text-orange-500 hover:text-orange-600 dark:text-orange-400 dark:hover:text-orange-300" %>
   <% end %>
 </div>

--- a/db/migrate/20260811160835_add_ruby_abi_to_deletions.rb
+++ b/db/migrate/20260811160835_add_ruby_abi_to_deletions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRubyAbiToDeletions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :deletions, :ruby_abi, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_23_061553) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_160835) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -148,6 +148,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_23_061553) do
     t.datetime "created_at", precision: nil, null: false
     t.string "number"
     t.string "platform"
+    t.string "ruby_abi"
     t.string "rubygem"
     t.datetime "updated_at", precision: nil, null: false
     t.integer "user_id"

--- a/script/restore_version
+++ b/script/restore_version
@@ -1,20 +1,24 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-gem_name, version_number, platform = *ARGV
+gem_name, version_number, platform, ruby_abi = *ARGV
 
-abort "Usage: script/restore_version GEM_NAME VESRION_NUMBER [PLATFORM]" if gem_name.nil? || version_number.nil?
+abort "Usage: script/restore_version GEM_NAME VERSION_NUMBER [PLATFORM] [RUBY_ABI]" if gem_name.nil? || version_number.nil?
 
 ENV["RAILS_ENV"] ||= "production"
 require_relative "../config/environment"
 
 rubygem = Rubygem.find_by_name!(gem_name)
-slug = version_number
+slug = version_number.dup
 slug << "-#{platform}" if platform.present?
-version = rubygem.find_version!(number: version_number, platform: platform)
-raise "Version #{slug} for #{gem_name} was not found" unless version
+slug << " (Ruby ABI #{ruby_abi})" if ruby_abi.present?
+begin
+  version = rubygem.find_version!(number: version_number, platform: platform, ruby_abi: ruby_abi.presence)
+rescue ActiveRecord::RecordNotFound
+  abort "Version #{slug} for #{gem_name} was not found"
+end
 
-deletion = Deletion.find_by(rubygem: gem_name, number: version_number, platform: version.platform)
+deletion = Deletion.find_by(rubygem: gem_name, number: version_number, platform: version.platform, ruby_abi: version.ruby_abi)
 raise "Deletion record for version: #{version.full_name} was not found" unless deletion
 
 deletion.version = version

--- a/test/functional/api/v1/deletions_controller_test.rb
+++ b/test/functional/api/v1/deletions_controller_test.rb
@@ -32,6 +32,131 @@ class Api::V1::DeletionsControllerTest < ActionController::TestCase
       end
     end
 
+    context "for a gem with content-addressable versions across Ruby ABIs" do
+      setup do
+        @rubygem = create(:rubygem, name: "sandworm")
+        @abi32 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.2"))
+        @abi34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.4"))
+        create(:ownership, user: @user, rubygem: @rubygem)
+        RubygemFs.instance.store("gems/#{@abi32.full_name}.gem", "")
+        RubygemFs.instance.store("gems/#{@abi34.full_name}.gem", "")
+      end
+
+      context "ON DELETE with a ruby_abi param" do
+        setup do
+          delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.2" }
+        end
+
+        should respond_with :success
+
+        should "yank only the targeted Ruby ABI variant" do
+          refute_predicate @abi32.reload, :indexed?
+          assert_predicate @abi34.reload, :indexed?
+        end
+
+        should "respond with the deleted variant including its content address and Ruby ABI" do
+          assert_includes @response.body, "Successfully deleted gem: sandworm (1.0.0-724c5206, Platform: x86_64-linux-musl, Ruby ABI 3.2)"
+        end
+      end
+
+      context "ON DELETE without a ruby_abi param" do
+        setup do
+          delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl" }
+        end
+
+        should respond_with :not_found
+
+        should "not yank either Ruby ABI variant" do
+          assert_predicate @abi32.reload, :indexed?
+          assert_predicate @abi34.reload, :indexed?
+        end
+
+        should "respond that the version does not exist" do
+          assert_includes @response.body, "The version 1.0.0 (x86_64-linux-musl) does not exist."
+        end
+      end
+
+      context "ON DELETE with a ruby_abi param that does not match any variant" do
+        setup do
+          delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.3" }
+        end
+
+        should respond_with :not_found
+
+        should "not yank either Ruby ABI variant" do
+          assert_predicate @abi32.reload, :indexed?
+          assert_predicate @abi34.reload, :indexed?
+        end
+
+        should "respond that the version does not exist" do
+          assert_includes @response.body, "The version 1.0.0 (x86_64-linux-musl) (Ruby ABI 3.3) does not exist."
+        end
+      end
+
+      context "ON DELETE with a ruby_abi param but no platform" do
+        setup do
+          delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", ruby_abi: "3.2" }
+        end
+
+        should respond_with :bad_request
+
+        should "not yank either Ruby ABI variant" do
+          assert_predicate @abi32.reload, :indexed?
+          assert_predicate @abi34.reload, :indexed?
+        end
+
+        should "respond that the platform param is required" do
+          assert_includes @response.body, "The platform param is required when ruby_abi is specified."
+        end
+      end
+
+      context "when a version supporting multiple Ruby ABIs coexists" do
+        setup do
+          @multi_abi = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                              required_ruby_version: ">= 3.2")
+          RubygemFs.instance.store("gems/#{@multi_abi.full_name}.gem", "")
+        end
+
+        context "ON DELETE with only a platform param" do
+          setup do
+            delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl" }
+          end
+
+          should respond_with :success
+
+          should "yank only the version supporting multiple Ruby ABIs and keep the single ABI variants" do
+            refute_predicate @multi_abi.reload, :indexed?
+            assert_predicate @abi32.reload, :indexed?
+            assert_predicate @abi34.reload, :indexed?
+          end
+
+          should "respond with the deleted platform version" do
+            assert_includes @response.body, "Successfully deleted gem: sandworm (1.0.0-x86_64-linux-musl)"
+          end
+        end
+
+        context "ON DELETE with an empty ruby_abi param" do
+          setup do
+            delete :create, params: { gem_name: @rubygem.slug, version: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "" }
+          end
+
+          should respond_with :success
+
+          should "treat the empty ruby_abi as absent and yank the version supporting multiple Ruby ABIs" do
+            refute_predicate @multi_abi.reload, :indexed?
+            assert_predicate @abi32.reload, :indexed?
+            assert_predicate @abi34.reload, :indexed?
+          end
+
+          should "respond with the deleted platform version" do
+            assert_includes @response.body, "Successfully deleted gem: sandworm (1.0.0-x86_64-linux-musl)"
+          end
+        end
+      end
+    end
+
     context "for a gem SomeGem with a version 0.1.0" do
       setup do
         @rubygem   = create(:rubygem, name: "SomeGem")

--- a/test/functional/api/v2/versions_controller_test.rb
+++ b/test/functional/api/v2/versions_controller_test.rb
@@ -68,6 +68,45 @@ class Api::V2::VersionsControllerTest < ActionController::TestCase
       create(:version, rubygem: @rubygem2, number: "1.0.0")
     end
 
+    context "with versions across Ruby ABIs" do
+      setup do
+        @rubygem = create(:rubygem, name: "sandworm")
+        @abi32 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.2"))
+        @abi34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-3.4"))
+        @multi = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: ">= 3.2", sha256: Digest::SHA2.base64digest("sandworm-1.0.0-multi"),
+                        spec_sha256: Digest::SHA2.base64digest("spec-multi"))
+      end
+
+      should "return the targeted Ruby ABI variant when ruby_abi is given" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.2", format: "json" }
+
+        assert_response :success
+        payload = JSON.parse(@response.body)
+
+        assert_equal "3.2", payload["ruby_abi"]
+        assert_equal @abi32.sha256_hex, payload["sha"]
+      end
+
+      should "return the version supporting multiple Ruby ABIs without a ruby_abi param" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", platform: "x86_64-linux-musl", format: "json" }
+
+        assert_response :success
+        payload = JSON.parse(@response.body)
+
+        assert_nil payload["ruby_abi"]
+        assert_equal @multi.sha256_hex, payload["sha"]
+      end
+
+      should "return not found for a ruby_abi that does not match any variant" do
+        get :show, params: { rubygem_name: @rubygem.name, number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.3", format: "json" }
+
+        assert_response :not_found
+      end
+    end
+
     should_respond_to(:json) do |body|
       JSON.parse(body)
     end

--- a/test/integration/rubygems/versions_test.rb
+++ b/test/integration/rubygems/versions_test.rb
@@ -27,4 +27,25 @@ class Rubygems::VersionsTest < ActionDispatch::IntegrationTest
     assert_includes response.headers["Surrogate-Control"], "max-age=60"
     assert_equal "gem/sandworm", response.headers["Surrogate-Key"]
   end
+
+  test "version navigation links resolve when adjacent versions are platformed or content-addressable" do
+    platformed = create(:version, rubygem: @rubygem, number: "2.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                        required_ruby_version: ">= 3.2")
+    addressed = create(:version, rubygem: @rubygem, number: "3.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                       required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("sandworm-3.0.0-3.4"))
+
+    get rubygem_version_path(@rubygem.slug, platformed.slug)
+
+    assert_response :success
+    doc = response.parsed_body
+
+    assert_equal rubygem_version_path(@rubygem.slug, @version.slug), doc.at_css(".gem__previous__version")["href"]
+    assert_equal rubygem_version_path(@rubygem.slug, addressed.slug), doc.at_css(".gem__next__version")["href"]
+
+    get doc.at_css(".gem__next__version")["href"]
+
+    assert_response :success
+    assert_equal rubygem_version_path(@rubygem.slug, platformed.slug),
+      response.parsed_body.at_css(".gem__previous__version")["href"]
+  end
 end

--- a/test/models/deletion_test.rb
+++ b/test/models/deletion_test.rb
@@ -185,6 +185,16 @@ class DeletionTest < ActiveSupport::TestCase
 
     assert_equal deletion.rubygem, @version.rubygem.name
     assert_equal @version.id, deletion.version_id
+    assert_nil deletion.ruby_abi
+  end
+
+  should "record the Ruby ABI for versions targeting a single Ruby ABI" do
+    version = create(:version, rubygem: @version.rubygem, number: "2.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                     required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("test-2.0.0-3.4"))
+    deletion = Deletion.new(version: version, user: @user)
+    deletion.valid?
+
+    assert_equal "3.4", deletion.ruby_abi
   end
 
   context "with restored gem" do

--- a/test/models/rubygem_test.rb
+++ b/test/models/rubygem_test.rb
@@ -80,6 +80,19 @@ class RubygemTest < ActiveSupport::TestCase
       assert_equal version3_ruby, @rubygem.most_recent_version
     end
 
+    should "find versions by number, platform and Ruby ABI" do
+      plain = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                     required_ruby_version: ">= 3.2")
+      abi34 = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
+                     required_ruby_version: "~> 3.4.0", ruby_abi: "3.4", sha256: Digest::SHA2.base64digest("abi34-1.0.0"))
+
+      assert_equal plain, @rubygem.find_version!(number: "1.0.0", platform: "x86_64-linux-musl")
+      assert_equal abi34, @rubygem.find_version!(number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.4")
+      assert_raises(ActiveRecord::RecordNotFound) do
+        @rubygem.find_version!(number: "1.0.0", platform: "x86_64-linux-musl", ruby_abi: "3.2")
+      end
+    end
+
     should "mark the latest version for each Ruby ABI per platform" do
       abi32_old = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux-musl", gem_platform: "x86_64-linux-musl",
                          required_ruby_version: "~> 3.2.0", ruby_abi: "3.2", sha256: Digest::SHA2.base64digest("abi32-1.0.0"))

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -159,6 +159,17 @@ class VersionTest < ActiveSupport::TestCase
       refute_predicate @dup_version, :valid?
     end
 
+    should "record the Ruby ABI on the pushed version event" do
+      version = create(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
+                       required_ruby_version: "~> 3.4.0", ruby_abi: "3.4",
+                       sha256: Digest::SHA2.base64digest("abi-event-1.0.0"))
+
+      pushed = @rubygem.events.where(tag: Events::RubygemEvent::VERSION_PUSHED).sole
+
+      assert_equal "3.4", pushed.additional.ruby_abi
+      assert_equal version.sha256_hex, pushed.additional.sha256
+    end
+
     should "not allow a ruby_abi that is not a Ruby minor version" do
       version = build(:version, rubygem: @rubygem, number: "1.0.0", platform: "x86_64-linux", gem_platform: "x86_64-linux",
                       required_ruby_version: "~> 3.4.0", ruby_abi: "banana",

--- a/test/system/avo/versions_test.rb
+++ b/test/system/avo/versions_test.rb
@@ -101,7 +101,7 @@ class Avo::VersionsSystemTest < ApplicationSystemTestCase
               "updated_at" => [deletion.updated_at.as_json, nil],
               "version_id" => [version.id, nil]
             },
-            "unchanged" => {}
+            "unchanged" => { "ruby_abi" => nil }
           },
           version_unyank_event.to_gid.to_s => {
             "changes" => version_unyank_event.attributes.transform_values { [nil, it] }.as_json,


### PR DESCRIPTION
https://github.com/rubygems/rubygems.org/pull/6674

## Link version navigation by slug so platformed variants resolve

### Problem

The previous/next links on the version show page are built from the version **number** alone:

```erb
rubygem_version_path(rubygem.slug, latest_version.previous.number)
```

That path resolves via `full_name = "name-number"` — only ever the plain-ruby variant. When the adjacent number exists **only** as platformed versions, the link has always 404ed (pre-existing bug); content-addressable variants make this much more likely, since every skinny gem's slug carries its content address.

`Version#previous`/`#next` also used `find_by(position: ±1)` — and `position` is ranked by number alone, so all variants of a number share a position and the lookup returned an arbitrary row.

### Fix

- Link `previous.slug` / `next.slug` — the slug encodes the platform or content address, so every variant shape resolves
- Make the adjacent-position lookup deterministic (`order(:id).first`)

### Testing

Integration test builds a gem with a plain version, a platformed version, and a content-addressable version, then walks the navigation in both directions asserting the exact hrefs (scoped to the nav link classes) and following them to a 200. Verified the test fails without the fix (the next-link href pointed at the bare number and 404ed).

Found during the content-addressable deep review; pre-existing on master but surfaced by ABI variants, hence targeting the feature branch where the test can cover the content-addressed case.
